### PR TITLE
Format examples

### DIFF
--- a/examples/crd/main.tf
+++ b/examples/crd/main.tf
@@ -7,7 +7,7 @@ resource "kubernetes_manifest" "test-crd" {
 
   manifest = {
     apiVersion = "apiextensions.k8s.io/v1"
-    kind = "CustomResourceDefinition"
+    kind       = "CustomResourceDefinition"
     metadata = {
       name = "testcrds.hashicorp.com"
       labels = {
@@ -17,13 +17,13 @@ resource "kubernetes_manifest" "test-crd" {
     spec = {
       group = "hashicorp.com"
       names = {
-        kind = "TestCrd"
+        kind   = "TestCrd"
         plural = "testcrds"
       }
       scope = "Namespaced"
       versions = [{
-        name = "v1"
-        served = true
+        name    = "v1"
+        served  = true
         storage = true
         schema = {
           openAPIV3Schema = {

--- a/examples/deployment/deployment.tf
+++ b/examples/deployment/deployment.tf
@@ -6,12 +6,12 @@ resource "kubernetes_manifest" "test-deployment" {
 
   manifest = {
     "apiVersion" = "apps/v1"
-    "kind" = "Deployment"
+    "kind"       = "Deployment"
     "metadata" = {
       "labels" = {
         "app" = "nginx"
       }
-      "name" = "nginx-deployment"
+      "name"      = "nginx-deployment"
       "namespace" = "default"
     }
     "spec" = {
@@ -31,11 +31,11 @@ resource "kubernetes_manifest" "test-deployment" {
           "containers" = [
             {
               "image" = "nginx:1.14.2"
-              "name" = "nginx"
+              "name"  = "nginx"
               "ports" = [
                 {
                   "containerPort" = 80
-                  "protocol" = "TCP"
+                  "protocol"      = "TCP"
                 },
               ]
             },

--- a/examples/ingress/ingress.tf
+++ b/examples/ingress/ingress.tf
@@ -6,12 +6,12 @@ resource "kubernetes_manifest" "test-ingress" {
 
   manifest = {
     "apiVersion" = "networking.k8s.io/v1beta1"
-    "kind" = "Ingress"
+    "kind"       = "Ingress"
     "metadata" = {
       "annotations" = {
         "nginx.ingress.kubernetes.io/rewrite-target" = "/$1"
       }
-      "name" = "example-ingress"
+      "name"      = "example-ingress"
       "namespace" = "default"
     }
     "spec" = {

--- a/examples/namespace/namespace.tf
+++ b/examples/namespace/namespace.tf
@@ -6,7 +6,7 @@ resource "kubernetes_manifest" "test-namespace" {
 
   manifest = {
     "apiVersion" = "v1"
-    "kind" = "Namespace"
+    "kind"       = "Namespace"
     "metadata" = {
       "name" = "tf-demo"
     }

--- a/examples/pod/pod.tf
+++ b/examples/pod/pod.tf
@@ -5,12 +5,12 @@ resource "kubernetes_manifest" "test-pod" {
   provider = kubernetes-alpha
   manifest = {
     "apiVersion" = "v1"
-    "kind" = "Pod"
+    "kind"       = "Pod"
     "metadata" = {
-      "name" = "label-demo"
+      "name"      = "label-demo"
       "namespace" = "default"
       "labels" = {
-        "app" = "nginx"
+        "app"         = "nginx"
         "environment" = "production"
       }
     }
@@ -18,11 +18,25 @@ resource "kubernetes_manifest" "test-pod" {
       "containers" = [
         {
           "image" = "nginx:1.7.9"
-          "name" = "nginx"
+          "name"  = "nginx"
           "ports" = [
             {
               "containerPort" = 80
-              "protocol" = "TCP"
+              "protocol"      = "TCP"
+            },
+          ]
+          env = [
+            {
+              "name" = "VAR1"
+              "valueFrom" = {
+                "fieldRef" = {
+                  "fieldPath" = "metadata.namespace"
+                }
+              }
+            },
+            {
+              "name"  = "VAR2"
+              "value" = "http://127.0.0.1:8200"
             },
           ]
         },

--- a/examples/role/role.tf
+++ b/examples/role/role.tf
@@ -7,12 +7,12 @@ resource "kubernetes_manifest" "test-role" {
 
   manifest = {
     "apiVersion" = "rbac.authorization.k8s.io/v1"
-    "kind" = "Role"
+    "kind"       = "Role"
     "metadata" = {
-      "name" = "pod-reader"
+      "name"      = "pod-reader"
       "namespace" = "default"
       "labels" = {
-        "app" = "test-app"
+        "app"         = "test-app"
         "environment" = "production"
       }
     }

--- a/examples/service/service.tf
+++ b/examples/service/service.tf
@@ -1,4 +1,5 @@
 provider "kubernetes-alpha" {
+  server_side_planning = true
 }
 
 variable "name" {
@@ -36,6 +37,7 @@ resource "kubernetes_manifest" "service-injector" {
         "app.kubernetes.io/name"     = "vault-agent-injector"
         "component"                  = "webhook"
       }
+      clusterIP = "10.111.133.169"
     }
   }
 }

--- a/examples/service/service.tf
+++ b/examples/service/service.tf
@@ -1,0 +1,41 @@
+provider "kubernetes-alpha" {
+}
+
+variable "name" {
+  default = "test-service"
+}
+
+variable "namespace" {
+  default = "default"
+}
+
+resource "kubernetes_manifest" "service-injector" {
+  provider = kubernetes-alpha
+  manifest = {
+    "apiVersion" = "v1"
+    "kind"       = "Service"
+    "metadata" = {
+      "labels" = {
+        "app.kubernetes.io/instance"   = var.name
+        "app.kubernetes.io/managed-by" = "Terraform"
+        "app.kubernetes.io/name"       = "vault-agent-injector"
+      }
+      "name"      = "${var.name}-vault-agent-injector-svc"
+      "namespace" = var.namespace
+    }
+    "spec" = {
+      "ports" = [
+        {
+          "port"       = 443
+          "targetPort" = "http"
+          "protocol"   = "TCP"
+        },
+      ]
+      "selector" = {
+        "app.kubernetes.io/instance" = "${var.name}"
+        "app.kubernetes.io/name"     = "vault-agent-injector"
+        "component"                  = "webhook"
+      }
+    }
+  }
+}

--- a/examples/service/service.tf
+++ b/examples/service/service.tf
@@ -37,7 +37,7 @@ resource "kubernetes_manifest" "service-injector" {
         "app.kubernetes.io/name"     = "vault-agent-injector"
         "component"                  = "webhook"
       }
-      clusterIP = "10.111.133.169"
+      clusterIP = "10.96.1.1"
     }
   }
 }

--- a/examples/terraform-operator/sync-workspace-role.tf
+++ b/examples/terraform-operator/sync-workspace-role.tf
@@ -1,6 +1,6 @@
 resource "kubernetes_role" "tfc-role" {
   metadata {
-    name = "${var.namespace}-sync-workspace"
+    name      = "${var.namespace}-sync-workspace"
     namespace = var.namespace
     labels = {
       app = var.namespace

--- a/examples/terraform-operator/sync-workspace-rolebinding.tf
+++ b/examples/terraform-operator/sync-workspace-rolebinding.tf
@@ -1,6 +1,6 @@
 resource "kubernetes_role_binding" "tfc-role-binding" {
   metadata {
-    name = "${var.namespace}-sync-workspace"
+    name      = "${var.namespace}-sync-workspace"
     namespace = var.namespace
     labels = {
       app = var.namespace
@@ -13,7 +13,7 @@ resource "kubernetes_role_binding" "tfc-role-binding" {
   }
   subject {
     kind      = "ServiceAccount"
-    name = kubernetes_service_account.tfc-service-account.metadata[0].name
+    name      = kubernetes_service_account.tfc-service-account.metadata[0].name
     namespace = var.namespace
   }
 }

--- a/examples/terraform-operator/sync-workspace-secret.tf
+++ b/examples/terraform-operator/sync-workspace-secret.tf
@@ -5,7 +5,7 @@ resource "kubernetes_secret" "workspace-secret" {
   }
 
   data = {
-    access_key_id     = var.access_key_id
+    access_key_id    = var.access_key_id
     secret_acess_key = var.secret_acess_key
   }
 }

--- a/examples/terraform-operator/sync-workspace-serviceaccount.tf
+++ b/examples/terraform-operator/sync-workspace-serviceaccount.tf
@@ -1,6 +1,6 @@
 resource "kubernetes_service_account" "tfc-service-account" {
   metadata {
-    name = "${var.namespace}-sync-workspace"
+    name      = "${var.namespace}-sync-workspace"
     namespace = var.namespace
     labels = {
       app = var.namespace

--- a/examples/terraform-operator/sync-workspaces-deployment.tf
+++ b/examples/terraform-operator/sync-workspaces-deployment.tf
@@ -1,6 +1,6 @@
 resource "kubernetes_deployment" "tfc-deployment" {
   metadata {
-    name = "${var.namespace}-sync-workspace"
+    name      = "${var.namespace}-sync-workspace"
     namespace = var.namespace
     labels = {
       app = var.namespace
@@ -12,20 +12,20 @@ resource "kubernetes_deployment" "tfc-deployment" {
 
     selector {
       match_labels = {
-        app = var.namespace
+        app       = var.namespace
         component = "sync-workspace"
       }
     }
     template {
       metadata {
         labels = {
-          app = var.namespace
+          app       = var.namespace
           component = "sync-workspace"
         }
       }
 
       spec {
-        service_account_name = kubernetes_service_account.tfc-service-account.metadata[0].name
+        service_account_name            = kubernetes_service_account.tfc-service-account.metadata[0].name
         automount_service_account_token = true
 
         volume {

--- a/examples/terraform-operator/variables.tf
+++ b/examples/terraform-operator/variables.tf
@@ -8,29 +8,29 @@ variable "tfc_credentials" {
 }
 
 variable "sync_workspace_image" {
-    description = "The terraform-k8s operator controller container image"
-    default = "hashicorp/terraform-k8s:0.1.2-alpha"
+  description = "The terraform-k8s operator controller container image"
+  default     = "hashicorp/terraform-k8s:0.1.2-alpha"
 }
 
 variable "terraformrc_secret_name" {
-    description = "Name of Kubernetes secret containing the Terraform CLI Configuration"
-    default = "terraformrc"
+  description = "Name of Kubernetes secret containing the Terraform CLI Configuration"
+  default     = "terraformrc"
 }
 
 variable "terraformrc_secret_key" {
-    description = "Key of Kubernetes secret containing the Terraform CLI Configuration"
-    default = "credentials"
+  description = "Key of Kubernetes secret containing the Terraform CLI Configuration"
+  default     = "credentials"
 }
 
 variable "workspace_secrets" {
-    description = "Name of Kubernetes secret containing keys and values of sensitive variables "
-    default = "workspacesecrets"
+  description = "Name of Kubernetes secret containing keys and values of sensitive variables "
+  default     = "workspacesecrets"
 }
 
 variable "access_key_id" {
-    description = "Cloud credential held by the workspace-secret"
+  description = "Cloud credential held by the workspace-secret"
 }
 
 variable "secret_acess_key" {
-    description = "Cloud credential held by the workspace-secret"
+  description = "Cloud credential held by the workspace-secret"
 }

--- a/examples/terraform-operator/workspaces.app.terraform.io.tf
+++ b/examples/terraform-operator/workspaces.app.terraform.io.tf
@@ -1,6 +1,6 @@
 
 provider "kubernetes-alpha" {
-  server_side_planning = "true"
+  server_side_planning = true
 }
 
 resource "kubernetes_manifest" "workspaces_app_terraform_io_crd" {


### PR DESCRIPTION
### Description

This change formats the example templates using `terraform fmt`

It also adds an example for a Service resource and complements the Pod example with env var attributes that have proven problematic in the past.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
