### PR TITLE
Workaround for IntOrString types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/terraform-provider-kubernetes-alpha
 go 1.14
 
 require (
-	github.com/alexsomesan/openapi-cty v0.0.2
+	github.com/alexsomesan/openapi-cty v0.0.4
 	github.com/davecgh/go-spew v1.1.1
 	github.com/golang/protobuf v1.3.3
 	github.com/google/go-cmp v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alexsomesan/openapi-cty v0.0.2 h1:s9UsAIVn0Ug4oNGTrnm/8VRsMZ01wtDou27NxLiM6Tg=
 github.com/alexsomesan/openapi-cty v0.0.2/go.mod h1:a+1dABgr2aehVHKcJwCVbVueZn6E6iFCC2C0zIU/nxQ=
+github.com/alexsomesan/openapi-cty v0.0.4 h1:ArJe9LEdJaZg2DokLL9/2hub/baUTFCJZMQgZk4WOeI=
+github.com/alexsomesan/openapi-cty v0.0.4/go.mod h1:a+1dABgr2aehVHKcJwCVbVueZn6E6iFCC2C0zIU/nxQ=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/apparentlymart/go-cidr v1.0.1 h1:NmIwLZ/KdsjIUlhf+/Np40atNXm/+lZ5txfTJ/SpF+U=
 github.com/apparentlymart/go-cidr v1.0.1/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=

--- a/vendor/github.com/alexsomesan/openapi-cty/foundry/foundry.go
+++ b/vendor/github.com/alexsomesan/openapi-cty/foundry/foundry.go
@@ -71,7 +71,16 @@ func (f foapiv2) resolveSchemaRef(ref *openapi3.SchemaRef) (*openapi3.Schema, er
 	rp := strings.Split(ref.Ref, "/")
 	sid := rp[len(rp)-1]
 
+	switch sid {
+	case "io.k8s.apimachinery.pkg.util.intstr.IntOrString":
+		t := openapi3.Schema{
+			Type: "integer",
+		}
+		return &t, nil
+	}
+
 	nref, ok := f.swagger.Definitions[sid]
+
 	if !ok {
 		return nil, errors.New("schema not found")
 	}
@@ -92,26 +101,23 @@ func (f foapiv2) getTypeFromSchema(elem *openapi3.Schema) (cty.Type, error) {
 	case "object":
 
 		switch {
-
 		case elem.Properties != nil && elem.AdditionalProperties == nil:
-
 			// this is a standard OpenAPI object
 			atts := make(map[string]cty.Type, len(elem.Properties))
 			for p, v := range elem.Properties {
-				s, err := f.resolveSchemaRef(v)
+				schema, err := f.resolveSchemaRef(v)
 				if err != nil {
 					return cty.NilType, fmt.Errorf("failed to resolve schema: %s", err)
 				}
-				pt, err := f.getTypeFromSchema(s)
+				pType, err := f.getTypeFromSchema(schema)
 				if err != nil {
 					return cty.NilType, err
 				}
-				atts[p] = pt
+				atts[p] = pType
 			}
 			return cty.Object(atts), nil
 
 		case elem.Properties == nil && elem.AdditionalProperties != nil:
-
 			// this is how OpenAPI defines associative arrays
 			s, err := f.resolveSchemaRef(elem.AdditionalProperties)
 			if err != nil {
@@ -121,7 +127,7 @@ func (f foapiv2) getTypeFromSchema(elem *openapi3.Schema) (cty.Type, error) {
 			if err != nil {
 				return cty.NilType, err
 			}
-			return cty.Tuple([]cty.Type{pt}), nil
+			return cty.Map(pt), nil
 
 		case elem.Properties == nil && elem.AdditionalProperties == nil:
 			// this is a strange case, encountered with io.k8s.apimachinery.pkg.apis.meta.v1.FieldsV1
@@ -130,7 +136,6 @@ func (f foapiv2) getTypeFromSchema(elem *openapi3.Schema) (cty.Type, error) {
 		}
 
 	case "array":
-
 		it, err := f.resolveSchemaRef(elem.Items)
 		if err != nil {
 			return cty.NilType, fmt.Errorf("failed to resolve schema for items: %s", err)
@@ -139,23 +144,22 @@ func (f foapiv2) getTypeFromSchema(elem *openapi3.Schema) (cty.Type, error) {
 		if err != nil {
 			return cty.NilType, err
 		}
-		return cty.Tuple([]cty.Type{t}), nil
+		return cty.List(t), nil
 
 	case "string":
-
 		return cty.String, nil
 
 	case "boolean":
-
 		return cty.Bool, nil
 
 	case "number":
-
 		return cty.Number, nil
 
 	case "integer":
-
 		return cty.Number, nil
+
+	case "":
+		return cty.DynamicPseudoType, nil
 
 	}
 	return cty.NilType, fmt.Errorf("unknown type: %s", elem.Type)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ cloud.google.com/go/internal/optional
 cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 cloud.google.com/go/storage
-# github.com/alexsomesan/openapi-cty v0.0.2
+# github.com/alexsomesan/openapi-cty v0.0.4
 ## explicit
 github.com/alexsomesan/openapi-cty/foundry
 # github.com/aws/aws-sdk-go v1.25.3


### PR DESCRIPTION
### Description
This change add a workaround to resolve IntOrString attributes as cty.Number, enabling users to specify numeric port numbers in attributes like e.g. Service.spec.ports.targetPort.
While this will disable the ability to specify string port designator, the prevailing use-case is for numeric port numbers. 

The definitive fix to this issue requires a more complex type to resolve to both Int or String, but this requires changes to handle such a type throughout the provider. A solution is being researched.

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
