### PR TITLE
Only build static binaries for platforms that support it

### DIFF
--- a/scripts/build_release_binaries.sh
+++ b/scripts/build_release_binaries.sh
@@ -10,14 +10,16 @@ if [ -z "$VERSION" ]; then
 fi
 
 # FIXME replace this with goreleaser
-OS_ARCH="freebsd/386 freebsd/amd64 freebsd/arm linux/386 linux/amd64 linux/arm openbsd/386 openbsd/amd64"
+OS_ARCH_STATIC="freebsd/386 freebsd/amd64 freebsd/arm linux/386 linux/amd64 linux/arm openbsd/386 openbsd/amd64"
+OS_ARCH="darwin/amd64 windows/amd64 windows/386"
 ASSETS_DIR="./release-bin"
 BINARY_NAME="terraform-provider-kubernetes-alpha"
 
 mkdir -p $ASSETS_DIR
 rm -rf $ASSETS_DIR/*
 
-gox -ldflags '-d -s -w' -osarch "$OS_ARCH" -output "$ASSETS_DIR/{{.Dir}}_${VERSION}_{{.OS}}_{{.Arch}}"
+gox -ldflags '-d -s -w' -osarch "$OS_ARCH_STATIC" -output "$ASSETS_DIR/{{.Dir}}_${VERSION}_{{.OS}}_{{.Arch}}"
+gox -ldflags '-s -w' -osarch "$OS_ARCH" -output "$ASSETS_DIR/{{.Dir}}_${VERSION}_{{.OS}}_{{.Arch}}"
 
 for f in $ASSETS_DIR/*; do
     mv $f $ASSETS_DIR/$BINARY_NAME


### PR DESCRIPTION
### Description

This change aims to fix the binary building script. 
Following a previous change to enable static binaries, the build script would fail with an error as not all platforms being built support static linking.

With this change, target platforms are separated into two groups. Ones that allow static builds are built as static binaries, while the rest are built as normal binaries with dynamic libc.

Tested by running the script locally on macOS

### Acceptance tests
- [x] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
