### PR TITLE
chore: install to terraforms plugin directory

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -9,8 +9,17 @@ default: build
 build: fmtcheck
 	go build
 
-install: fmtcheck
-	go install
+install: GOOS=$(shell go env GOOS)
+install: GOARCH=$(shell go env GOARCH)
+ifeq ($(OS),Windows_NT)  # is Windows_NT on XP, 2000, 7, Vista, 10...
+install: DESTINATION=$(APPDATA)/terraform.d/plugins/$(GOOS)_$(GOARCH)
+else
+install: DESTINATION=$(HOME)/.terraform.d/plugins/$(GOOS)_$(GOARCH)
+endif
+install: build
+	@echo "==> Installing plugin to $(DESTINATION)"
+	@mkdir -p $(DESTINATION)
+	@cp ./terraform-provider-kubernetes-alpha $(DESTINATION)
 
 test: fmtcheck
 	go test $(TEST) -v || exit 1


### PR DESCRIPTION
👋  folks,
I was trying out the alpha provider and ran into issues due to the CI failures causing nightlies to not be up to date. I somewhat expected `make install` to install the provider into a usable place, and was surprised when it didn't.

Filling this to simplify the testing and installation workflow for others, but understand if you don't want to merge this and would rather folks build/copy manually.