### PR TITLE
Add host.IsKnown() to avoid unknown value error

### DIFF
--- a/provider/server.go
+++ b/provider/server.go
@@ -421,8 +421,7 @@ func (s *RawProviderServer) Configure(ctx context.Context, req *tfplugin5.Config
 	clientConfig, err := cc.ClientConfig()
 	if err != nil {
 		Dlog.Printf("[Configure] Failed to load config:\n%s\n", spew.Sdump(cc))
-		// TODO: improve the way of detecting this error
-		if err.Error() == "invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable" {
+		if errors.Is(err, clientcmd.ErrEmptyConfig) {
 			// this is a terrible fix for if the configuration is a calculated value
 			return response, nil
 		}

--- a/provider/server.go
+++ b/provider/server.go
@@ -101,7 +101,7 @@ func (s *RawProviderServer) PrepareProviderConfig(ctx context.Context, req *tfpl
 	}
 
 	host := providerConfig.GetAttr("host")
-	if !host.IsNull() {
+	if !host.IsNull() && host.IsKnown() {
 		_, err = url.ParseRequestURI(host.AsString())
 		if err != nil {
 			diags = append(diags, &tfplugin5.Diagnostic{
@@ -122,7 +122,7 @@ func (s *RawProviderServer) PrepareProviderConfig(ctx context.Context, req *tfpl
 	}
 
 	pemCA := providerConfig.GetAttr("cluster_ca_certificate")
-	if !pemCA.IsNull() {
+	if !pemCA.IsNull() && host.IsKnown() {
 		pem, _ := pem.Decode([]byte(pemCA.AsString()))
 		if pem == nil || pem.Type != "CERTIFICATE" {
 			diags = append(diags, &tfplugin5.Diagnostic{
@@ -143,7 +143,7 @@ func (s *RawProviderServer) PrepareProviderConfig(ctx context.Context, req *tfpl
 	}
 
 	pemCC := providerConfig.GetAttr("client_certificate")
-	if !pemCC.IsNull() {
+	if !pemCC.IsNull() && host.IsKnown() {
 		pem, _ := pem.Decode([]byte(pemCC.AsString()))
 		if pem == nil || pem.Type != "CERTIFICATE" {
 			diags = append(diags, &tfplugin5.Diagnostic{
@@ -164,7 +164,7 @@ func (s *RawProviderServer) PrepareProviderConfig(ctx context.Context, req *tfpl
 	}
 
 	pemCK := providerConfig.GetAttr("client_key")
-	if !pemCK.IsNull() {
+	if !pemCK.IsNull() && host.IsKnown() {
 		pem, _ := pem.Decode([]byte(pemCK.AsString()))
 		if pem == nil || !strings.Contains(pem.Type, "PRIVATE KEY") {
 			diags = append(diags, &tfplugin5.Diagnostic{

--- a/provider/server.go
+++ b/provider/server.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -22,7 +23,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -514,7 +515,7 @@ func (s *RawProviderServer) ReadResource(ctx context.Context, req *tfplugin5.Rea
 		fo, err = rcl.Get(ctx, rname, v1.GetOptions{})
 	}
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return resp, nil
 		}
 		d := tfplugin5.Diagnostic{


### PR DESCRIPTION
# Description 

When providing the cluster credentials as output of another provider you currently get a panic as the value is unknown, this adds an extra check to avoid that which makes the provider accept the credentials.

Might not be the best way, feedback welcome!

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
