### PR TITLE
Sign releases for MacOS and Windows

### DIFF
--- a/.github/workflows/release_binaries.yaml
+++ b/.github/workflows/release_binaries.yaml
@@ -18,10 +18,27 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ steps.go-version.outputs.content }}
-      - name: Release
+      - name: Docker Login
+        uses: azure/docker-login@v1
+        with:
+          login-server: docker.pkg.github.com
+          username: docker
+          password: ${{ secrets.CODESIGN_GITHUB_TOKEN }}
+      - id: codesign
+        name: Pull hc-codesign image
+        run: |
+          docker pull docker.pkg.github.com/hashicorp/hc-codesign/hc-codesign:$VERSION
+          echo "::set-output name=image::docker.pkg.github.com/hashicorp/hc-codesign/hc-codesign:$VERSION"
+        env:
+          VERSION: v0
+     - name: Release
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN:      ${{ secrets.GITHUB_TOKEN }}
+          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
+          ARTIFACTORY_USER:  ${{ secrets.ARTIFACTORY_USER }}
+          CIRCLE_TOKEN:      ${{ secrets.CIRCLE_TOKEN }}
+          CODESIGN_IMAGE:    ${{ steps.codesign.outputs.image }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,9 +6,22 @@ before:
     - make test
 
 builds:
-  - id: build
+  - id: signed
     targets:
       - darwin_amd64
+      - windows_386
+      - windows_amd64
+    hooks:
+      post: |
+        docker run
+          -e ARTIFACTORY_TOKEN={{ .Env.ARTIFACTORY_TOKEN }}
+          -e ARTIFACTORY_USER={{ .Env.ARTIFACTORY_USER }}
+          -e CIRCLE_TOKEN={{ .Env.CIRCLE_TOKEN }}
+          -v {{ dir .Path }}:/workdir
+          {{ .Env.CODESIGN_IMAGE }}
+          sign -product-name={{ .ProjectName }} {{ .Name }}
+  - id: unsigned
+    targets:
       - freebsd_386
       - freebsd_amd64
       - freebsd_arm
@@ -18,8 +31,6 @@ builds:
       - openbsd_386
       - openbsd_amd64
       - solaris_amd64
-      - windows_386
-      - windows_amd64
 
 release:
   github:


### PR DESCRIPTION
Add hc-codesign back to the release workflow.