### PR TITLE
Defer client initialization

### DIFF
--- a/examples/cluster-with-resources/README.md
+++ b/examples/cluster-with-resources/README.md
@@ -1,0 +1,67 @@
+# Provision a cluster on AKS and install Kubernetes manifests
+
+This example demonstrates how to use the provider together with a cluster provisioned on Azure's AKS.
+
+**It's important to be aware that this example will not work as expected when applied with Terraform as a single operation.**
+
+This is because the provider requires access to the Kubernetes API during the planning phase. Initially, before any resources have been created, there is no available API endpoint and the provider will throw an error.
+
+This example demonstrates how to group resources related to the cluster in their own module and the Kubernetes manifests in another separate module, to facilitate building in distinct stages.
+
+It is still possible to build this configuration and obtain a single state file. For this, two Terraform operations are necessary.
+
+Before anything, make sure your environment is configured with valid Azure credentials.
+In paricular, have these environment variables set to relevant values in your Azure account:
+```
+ARM_SUBSCRIPTION_ID￼￼
+ARM_TENANT_ID￼￼
+ARM_CLIENT_ID (a.k.a. App ID)
+ARM_CLIENT_SECRET (a.k.a. password)
+```
+
+Initialize the workspace:
+
+```shell
+ » terraform init
+```
+
+The first Terraform apply operation will build just the AKS cluster and other resources it may require. For this, we use the `-target` argument to Terraform to limit the scope of the apply.
+
+```shell
+ » terraform apply -target module.cluster
+```
+
+Once this operation succeeds, the AKS cluster is available and the state file contains its attribute values.
+
+Running `terraform state list` should show the following resources present in the state:
+
+```shell
+ » terraform state list
+module.cluster.azurerm_kubernetes_cluster.test
+module.cluster.azurerm_resource_group.test
+module.cluster.local_file.kubeconfig
+```
+
+At this point the Kubernetes provider is able to access the cluster API. The second apply operation will build the rest of the resources successfully.
+
+Run the second apply operation:
+
+```shell
+terraform apply
+```
+
+At this point all the resources should be successfully created and present in the state file.
+
+```shell
+ » terraform state list
+module.cluster.azurerm_kubernetes_cluster.test
+module.cluster.azurerm_resource_group.test
+module.cluster.local_file.kubeconfig
+module.manifests.kubernetes_manifest.test-cfm
+```
+
+The provider will also produce a credentials file called `kubeconfig.test` for use with `kubectl` to facilitate validation of the created resources. You can run commands against the cluster like this:
+
+```shell
+ » kubectl --kubeconfig kubeconfig.test ...
+```

--- a/examples/cluster-with-resources/cluster/test.tf
+++ b/examples/cluster-with-resources/cluster/test.tf
@@ -1,0 +1,69 @@
+variable "location" {
+  type = string
+}
+
+data "azurerm_kubernetes_service_versions" "current" {
+  location = var.location
+}
+resource "azurerm_resource_group" "test" {
+  name     = "k8s-alpha-test"
+  location = var.location
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "k8s-alpha-aks"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "k8s-alpha-aks"
+
+  kubernetes_version = data.azurerm_kubernetes_service_versions.current.latest_version
+
+  default_node_pool {
+    name            = "default"
+    vm_size         = "Standard_D2_v2"
+    os_disk_size_gb = 30
+    node_count      = 2
+    type            = "AvailabilitySet"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  role_based_access_control {
+    enabled = true
+  }
+
+  tags = {
+    environment = "k8s-alpha"
+  }
+}
+
+resource "local_file" "kubeconfig" {
+  content  = azurerm_kubernetes_cluster.test.kube_config_raw
+  filename = "kubeconfig.test"
+}
+
+output "host" {
+  value = azurerm_kubernetes_cluster.test.kube_config.0.host
+}
+
+output "cluster_ca_certificate" {
+  value = base64decode(azurerm_kubernetes_cluster.test.kube_config.0.cluster_ca_certificate)
+}
+
+output "client_certificate" {
+  value = base64decode(azurerm_kubernetes_cluster.test.kube_config.0.client_certificate)
+}
+
+output "client_key" {
+  value = base64decode(azurerm_kubernetes_cluster.test.kube_config.0.client_key)
+}
+
+output "cluster_resource_group" {
+  value = azurerm_resource_group.test.name
+}
+
+output "cluster_name" {
+  value = azurerm_kubernetes_cluster.test.name
+}

--- a/examples/cluster-with-resources/main.tf
+++ b/examples/cluster-with-resources/main.tf
@@ -1,0 +1,46 @@
+variable "server_side_planning" {
+  type    = bool
+  default = true
+}
+
+variable "location" {
+  type    = string
+  default = "West Europe"
+}
+
+
+/*
+  This creates a simple cluster on AKS.
+*/
+provider "azurerm" {
+  version = ">=2.20.0"
+  features {}
+}
+
+module "cluster" {
+  source   = "./cluster"
+  location = var.location
+}
+
+
+/*
+  Here we create the Kubernetes resources on the AKS cluster.
+  
+  IMPORTANT: there is no explicit or implecit way to express dependency 
+  of the Kubernetes resource on the AKS resource being present.
+  You must split the apply into two operations. See README.md
+*/
+
+provider "kubernetes-alpha" {
+  server_side_planning = var.server_side_planning
+
+  host                   = module.cluster.host
+  cluster_ca_certificate = module.cluster.cluster_ca_certificate
+  client_certificate     = module.cluster.client_certificate
+  client_key             = module.cluster.client_key
+}
+
+module "manifests" {
+  source       = "./manifests"
+  cluster_name = module.cluster.cluster_name
+}

--- a/examples/cluster-with-resources/main.tf
+++ b/examples/cluster-with-resources/main.tf
@@ -26,7 +26,7 @@ module "cluster" {
 /*
   Here we create the Kubernetes resources on the AKS cluster.
   
-  IMPORTANT: there is no explicit or implecit way to express dependency 
+  IMPORTANT: there is no explicit or implicit way to express dependency 
   of the Kubernetes resource on the AKS resource being present.
   You must split the apply into two operations. See README.md
 */

--- a/examples/cluster-with-resources/manifests/test.tf
+++ b/examples/cluster-with-resources/manifests/test.tf
@@ -1,0 +1,22 @@
+variable "cluster_name" {
+  type = string
+}
+
+resource "kubernetes_manifest" "test-cfm" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    "apiVersion" = "v1"
+    "kind" = "ConfigMap"
+    "metadata" = {
+      "name" = "test-cf"
+      "namespace" = "default"
+      "labels" = {
+        "parent_cluster" = var.cluster_name
+      }
+    }
+    "data" = {
+      "parent_cluster" = var.cluster_name
+    }
+  }
+}

--- a/provider/clients.go
+++ b/provider/clients.go
@@ -8,15 +8,18 @@ import (
 	"github.com/alexsomesan/openapi-cty/foundry"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 )
 
 var providerState map[string]interface{}
 
 // keys into the provider state storage
 const (
+	ClientConfig    string = "CLIENTCONFIG"
 	DynamicClient   string = "DYNAMICCLIENT"
 	DiscoveryClient string = "DISCOVERYCLIENT"
 	RestClient      string = "RESTCLIENT"
@@ -33,44 +36,89 @@ func GetProviderState() map[string]interface{} {
 	return providerState
 }
 
+// GetClientConfig returns the client.Config produced from the
+// provider block attribues
+func GetClientConfig() (*rest.Config, error) {
+	s := GetProviderState()
+	c, ok := s[ClientConfig]
+	if !ok {
+		return nil, fmt.Errorf("no client configuration")
+	}
+	return c.(*rest.Config), nil
+}
+
 // GetDynamicClient returns a configured unstructured (dynamic) client instance
 func GetDynamicClient() (dynamic.Interface, error) {
 	s := GetProviderState()
 	c, ok := s[DynamicClient]
-	if !ok {
-		return nil, fmt.Errorf("no dynamic client configured")
+	if ok {
+		return c.(dynamic.Interface), nil
 	}
-	return c.(dynamic.Interface), nil
+	clientConfig, err := GetClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	dynClient, err := dynamic.NewForConfig(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+	s[DynamicClient] = dynClient
+	return dynClient, nil
 }
 
 // GetDiscoveryClient returns a configured discyovery client instance
 func GetDiscoveryClient() (discovery.DiscoveryInterface, error) {
 	s := GetProviderState()
 	c, ok := s[DiscoveryClient]
-	if !ok {
-		return nil, fmt.Errorf("no discovery client configured")
+	if ok {
+		return c.(*discovery.DiscoveryClient), nil
 	}
-	return c.(discovery.DiscoveryInterface), nil
+	clientConfig, err := GetClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	discoClient, err := discovery.NewDiscoveryClientForConfig(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+	s[DiscoveryClient] = discoClient
+	return discoClient, nil
 }
 
 // GetRestMapper returns a RESTMapper client instance
 func GetRestMapper() (meta.RESTMapper, error) {
 	s := GetProviderState()
 	c, ok := s[RestMapper]
-	if !ok {
-		return nil, fmt.Errorf("no REST mapper client configured")
+	if ok {
+		return c.(meta.RESTMapper), nil
 	}
-	return c.(meta.RESTMapper), nil
+	dc, err := GetDiscoveryClient()
+	if err != nil {
+		return nil, err
+	}
+	cacher := memory.NewMemCacheClient(dc)
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(cacher)
+	s[RestMapper] = mapper
+	return mapper, nil
 }
 
 // GetRestClient returns a raw REST client instance
 func GetRestClient() (rest.Interface, error) {
 	s := GetProviderState()
 	c, ok := s[RestClient]
-	if !ok {
-		return nil, fmt.Errorf("no REST client configured")
+	if ok {
+		return c.(rest.Interface), nil
 	}
-	return c.(rest.Interface), nil
+	clientConfig, err := GetClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	restClient, err := rest.UnversionedRESTClientFor(clientConfig)
+	if err != nil {
+		return nil, err
+	}
+	s[RestClient] = restClient
+	return restClient, nil
 }
 
 // GetOAPIFoundry returns an interface to request cty types from an OpenAPI spec

--- a/provider/clients.go
+++ b/provider/clients.go
@@ -66,7 +66,7 @@ func GetDynamicClient() (dynamic.Interface, error) {
 	return dynClient, nil
 }
 
-// GetDiscoveryClient returns a configured discyovery client instance
+// GetDiscoveryClient returns a configured discovery client instance.
 func GetDiscoveryClient() (discovery.DiscoveryInterface, error) {
 	s := GetProviderState()
 	c, ok := s[DiscoveryClient]

--- a/provider/clients.go
+++ b/provider/clients.go
@@ -37,7 +37,7 @@ func GetProviderState() map[string]interface{} {
 }
 
 // GetClientConfig returns the client.Config produced from the
-// provider block attribues
+// provider block attributes.
 func GetClientConfig() (*rest.Config, error) {
 	s := GetProviderState()
 	c, ok := s[ClientConfig]

--- a/provider/resource_hcl.go
+++ b/provider/resource_hcl.go
@@ -14,7 +14,7 @@ import (
 // PlanUpdateResourceHCL decides whether to off-load the change planning
 // to the API server via a dry-run call or compute the changes locally
 func PlanUpdateResourceHCL(ctx context.Context, in *cty.Value) (cty.Value, error) {
-	s := GetProviderState()
+	s := GetGlobalState()
 	if s[SSPlanning].(bool) {
 		return PlanUpdateResourceHCLServerSide(ctx, in)
 	}

--- a/provider/server.go
+++ b/provider/server.go
@@ -84,7 +84,7 @@ func (s *RawProviderServer) PrepareProviderConfig(ctx context.Context, req *tfpl
 			diags = append(diags, &tfplugin5.Diagnostic{
 				Severity: tfplugin5.Diagnostic_INVALID,
 				Summary:  "Invalid attribute in provider configuration",
-				Detail:   "'config_path' refers to an invalid file path",
+				Detail:   "'config_path' refers to an invalid file path: " + configPathAbs,
 				Attribute: &tfplugin5.AttributePath{
 					Steps: []*tfplugin5.AttributePath_Step{
 						{

--- a/provider/server.go
+++ b/provider/server.go
@@ -172,8 +172,8 @@ func (s *RawProviderServer) Configure(ctx context.Context, req *tfplugin5.Config
 
 	pemCC := providerConfig.GetAttr("client_certificate")
 	if !pemCC.IsNull() && host.IsKnown() {
-		pem, _ := pem.Decode([]byte(pemCC.AsString()))
-		if pem == nil || pem.Type != "CERTIFICATE" {
+		cc, _ := pem.Decode([]byte(pemCC.AsString()))
+		if cc == nil || cc.Type != "CERTIFICATE" {
 			diags = append(diags, &tfplugin5.Diagnostic{
 				Severity: tfplugin5.Diagnostic_INVALID,
 				Summary:  "Invalid attribute in provider configuration",
@@ -193,8 +193,8 @@ func (s *RawProviderServer) Configure(ctx context.Context, req *tfplugin5.Config
 
 	pemCA := providerConfig.GetAttr("cluster_ca_certificate")
 	if !pemCA.IsNull() && host.IsKnown() {
-		pem, _ := pem.Decode([]byte(pemCA.AsString()))
-		if pem == nil || pem.Type != "CERTIFICATE" {
+		ca, _ := pem.Decode([]byte(pemCA.AsString()))
+		if ca == nil || ca.Type != "CERTIFICATE" {
 			diags = append(diags, &tfplugin5.Diagnostic{
 				Severity: tfplugin5.Diagnostic_INVALID,
 				Summary:  "Invalid attribute in provider configuration",
@@ -214,8 +214,8 @@ func (s *RawProviderServer) Configure(ctx context.Context, req *tfplugin5.Config
 
 	pemCK := providerConfig.GetAttr("client_key")
 	if !pemCK.IsNull() && host.IsKnown() {
-		pem, _ := pem.Decode([]byte(pemCK.AsString()))
-		if pem == nil || !strings.Contains(pem.Type, "PRIVATE KEY") {
+		ck, _ := pem.Decode([]byte(pemCK.AsString()))
+		if ck == nil || !strings.Contains(ck.Type, "PRIVATE KEY") {
 			diags = append(diags, &tfplugin5.Diagnostic{
 				Severity: tfplugin5.Diagnostic_INVALID,
 				Summary:  "Invalid attribute in provider configuration",

--- a/provider/server.go
+++ b/provider/server.go
@@ -238,7 +238,7 @@ func (s *RawProviderServer) Configure(ctx context.Context, req *tfplugin5.Config
 		return response, errors.New("failed to validate provider configuration")
 	}
 
-	ps := GetProviderState()
+	ps := GetGlobalState()
 
 	ssp := providerConfig.GetAttr("server_side_planning")
 	if !ssp.IsKnown() || ssp.IsNull() {


### PR DESCRIPTION
### Description
This change complements #65 and ensures that client instances are created as late as possible, right before the first API call needs to be made. 

In turn, this ensures that any incomplete transient credentials are not passed to the client, avoiding the consequent early failures.

Notably, this also fixes a provider failure mode where a missing kubeconfig file would cause Terraform to crash.

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [x] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
