### PR TITLE
Add wait_for block to kubernetes_manifest resource

### DIFF
--- a/examples/wait/main.tf
+++ b/examples/wait/main.tf
@@ -1,0 +1,37 @@
+provider "kubernetes-alpha" {
+  config_path = "~/.kube/config"
+  server_side_planning = true
+}
+
+resource "kubernetes_manifest" "example" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Pod"
+
+    metadata = {
+      name      = "example-pod"
+      namespace = "default"
+
+      labels = {
+        app = "nginx"
+      }
+    }
+
+    spec = {
+      containers = [
+        {
+          image = "nginx:1.19"
+          name  = "nginx"
+        },
+      ]
+    }
+  }
+
+  wait_for {
+    fields = {
+      "status.phase" = "Running"
+    }
+  }
+}

--- a/go.sum
+++ b/go.sum
@@ -420,6 +420,7 @@ github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/provider/waiter.go
+++ b/provider/waiter.go
@@ -1,0 +1,160 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-cty/cty"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+)
+
+// Waiter is a simple interface to implement a blocking wait operation
+type Waiter interface {
+	Wait(context.Context) error
+}
+
+// NewResourceWaiter constructs an appropriate Waiter using the supplied waitForBlock configuration
+func NewResourceWaiter(resource dynamic.ResourceInterface, resourceName string, waitForBlock cty.Value) (Waiter, error) {
+	fields := waitForBlock.GetAttr("fields")
+
+	if !fields.IsNull() || fields.IsKnown() {
+		if !fields.Type().IsMapType() {
+			return nil, fmt.Errorf(`"fields" should be a map of strings`)
+		}
+
+		vm := fields.AsValueMap()
+		matchers := []FieldMatcher{}
+		for k, v := range vm {
+			expr := v.AsString()
+			var re *regexp.Regexp
+			if expr == "*" {
+				// NOTE this is just a shorthand so the user doesn't have to
+				// type the expression below all the time
+				re = regexp.MustCompile("(.*)?")
+			} else {
+				var err error
+				re, err = regexp.Compile(expr)
+				if err != nil {
+					return nil, fmt.Errorf("invalid regular expression: %q", expr)
+				}
+			}
+
+			matchers = append(matchers, FieldMatcher{FieldPathToCty(k), re})
+		}
+
+		return &FieldWaiter{
+			resource,
+			resourceName,
+			matchers,
+		}, nil
+	}
+
+	return &NoopWaiter{}, nil
+}
+
+// FieldMatcher contains a cty Path to a field and a regexp to match on it
+type FieldMatcher struct {
+	path         cty.Path
+	valueMatcher *regexp.Regexp
+}
+
+// FieldWaiter will wait for a set of fields to be set,
+// or have a particular value
+type FieldWaiter struct {
+	resource      dynamic.ResourceInterface
+	resourceName  string
+	fieldMatchers []FieldMatcher
+}
+
+// Wait blocks until all of the FieldMatchers configured evaluate to true
+func (w *FieldWaiter) Wait(ctx context.Context) error {
+	return wait(ctx, w.resource, w.resourceName, func(obj cty.Value) (bool, error) {
+		for _, m := range w.fieldMatchers {
+			v, err := m.path.Apply(obj)
+			if err != nil {
+				return false, err
+			}
+
+			if !m.valueMatcher.Match([]byte(v.AsString())) {
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+}
+
+// NoopWaiter is a placeholder for when there is nothing to wait on
+type NoopWaiter struct{}
+
+// Wait returns immediately
+func (w *NoopWaiter) Wait(_ context.Context) error {
+	return nil
+}
+
+func wait(ctx context.Context, resource dynamic.ResourceInterface, resourceName string, condition func(cty.Value) (bool, error)) error {
+	w, err := resource.Watch(ctx, v1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("metadata.name", resourceName).String(),
+		Watch:         true,
+	})
+	if err != nil {
+		return err
+	}
+
+	Dlog.Printf("[ApplyResourceChange][Wait] Waiting until ready...\n")
+	for e := range w.ResultChan() {
+		Dlog.Printf("%v\n", e.Type)
+
+		if e.Type == watch.Deleted {
+			return fmt.Errorf("resource was deleted")
+		}
+
+		if e.Type == watch.Error {
+			Dlog.Printf("Error when watching: %#v", e.Object)
+			return fmt.Errorf("watch error")
+		}
+
+		// NOTE the typed API resource is actually returned in the
+		// event object but I haven't yet figured out how to convert it
+		// to a cty.Value
+		res, err := resource.Get(ctx, resourceName, v1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		obj, err := UnstructuredToCty(res.Object)
+		if err != nil {
+			return err
+		}
+
+		done, err := condition(obj)
+		if done {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// FieldPathToCty takes a string representation of
+// a path to a field in dot notation parses into a cty.Path
+func FieldPathToCty(path string) cty.Path {
+	ctyPath := cty.Path{}
+
+	parts := strings.Split(path, ".")
+	for _, part := range parts {
+		if index, err := strconv.Atoi(part); err == nil {
+			ctyPath = ctyPath.IndexInt(index)
+		} else {
+			ctyPath = ctyPath.GetAttr(part)
+		}
+	}
+
+	return ctyPath
+}


### PR DESCRIPTION
### Description

This PR adds the `wait_for` block to the kubernetes_manifest resource and implements the `fields` attribute allowing you to block the create and update operations until the field is set or matches a particular value or regular expression.


### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
