### PR TITLE
Update README with registry changes (#58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ Our eventual goal is for this generic resource to become a part of our [official
 
 If this is your first time here, you can get an overview of the provider by reading our [introductory blog post](https://www.hashicorp.com/blog/deploy-any-resource-with-the-new-kubernetes-provider-for-hashicorp-terraform/).
 
-Otherwise, start by downloading a copy of our latest build from the [releases page](https://github.com/hashicorp/terraform-provider-kubernetes-alpha/releases).
-
-You'll need to unzip the release download and copy the binary into your [Terraform plugins folder](https://www.terraform.io/docs/plugins/basics.html#installing-plugins) in order for Terraform to discover it.
+Otherwise, start by installing the latest release from the [Terraform registry](https://registry.terraform.io/providers/hashicorp/kubernetes-alpha/latest).
 
 Once you have the plugin installed, review the [usage document](https://github.com/hashicorp/terraform-provider-kubernetes-alpha/docs/usage.md) in the [docs](https://github.com/hashicorp/terraform-provider-kubernetes-alpha/docs/) folder to understand which configuration options are available. You can find the following examples and more in [our examples folder](https://github.com/hashicorp/terraform-provider-kubernetes-alpha/examples/). Don't forget to run `terraform init` in your Terraform configuration directory to allow Terraform to detect the provider plugin.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Otherwise, start by downloading a copy of our latest build from the [releases pa
 
 You'll need to unzip the release download and copy the binary into your [Terraform plugins folder](https://www.terraform.io/docs/plugins/basics.html#installing-plugins) in order for Terraform to discover it.
 
-Once you have the plugin installed, review the [usage document](docs/usage.md) in the [docs](docs/) folder to understand which configuration options are available. You can find the following examples and more in [our examples folder](examples/). Don't forget to run `terraform init` in your Terraform configuration directory to allow Terraform to detect the provider plugin.
+Once you have the plugin installed, review the [usage document](https://github.com/hashicorp/terraform-provider-kubernetes-alpha/docs/usage.md) in the [docs](https://github.com/hashicorp/terraform-provider-kubernetes-alpha/docs/) folder to understand which configuration options are available. You can find the following examples and more in [our examples folder](https://github.com/hashicorp/terraform-provider-kubernetes-alpha/examples/). Don't forget to run `terraform init` in your Terraform configuration directory to allow Terraform to detect the provider plugin.
 
 ### Create a Kubernetes ConfigMap
 ```hcl
@@ -151,7 +151,7 @@ Alternatively, there is also an experimental command line tool [tfk8s](https://g
 
 We welcome your contribution. Please understand that the experimental nature of this repository means that contributing code may be a bit of a moving target. If you have an idea for an enhancement or bug fix, and want to take on the work yourself, please first [create an issue](https://github.com/hashicorp/terraform-provider-kubernetes-alpha/issues/new/choose) so that we can discuss the implementation with you before you proceed with the work.
 
-You can review our [contribution guide](_about/CONTRIBUTING.md) to begin. You can also check out our [frequently asked questions](_about/FAQ.md).
+You can review our [contribution guide](https://github.com/hashicorp/terraform-provider-kubernetes-alpha/_about/CONTRIBUTING.md) to begin. You can also check out our [frequently asked questions](https://github.com/hashicorp/terraform-provider-kubernetes-alpha/_about/FAQ.md).
 
 ## Experimental Status
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,7 +72,7 @@ By using the software in this repository (the "Software"), you acknowledge that:
 
 If this is your first time here, you can get an overview of the provider by reading our [introductory blog post](https://www.hashicorp.com/blog/deploy-any-resource-with-the-new-kubernetes-provider-for-hashicorp-terraform/).
 
-Next, review the "Schema" section above to understand which configuration options are available. You can find the following examples and more in [our examples folder](examples/). Don't forget to run `terraform init` in your Terraform configuration directory to allow Terraform to detect the provider plugin.
+Next, review the "Schema" section above to understand which configuration options are available. You can find the following examples and more in [our examples folder](https://github.com/hashicorp/terraform-provider-kubernetes-alpha/examples/). Don't forget to run `terraform init` in your Terraform configuration directory to allow Terraform to detect the provider plugin.
 
 ### Create a Kubernetes ConfigMap
 ```hcl
@@ -192,4 +192,4 @@ Alternatively, there is also an experimental command line tool [tfk8s](https://g
 
 We welcome your contribution. Please understand that the experimental nature of this repository means that contributing code may be a bit of a moving target. If you have an idea for an enhancement or bug fix, and want to take on the work yourself, please first [create an issue](https://github.com/hashicorp/terraform-provider-kubernetes-alpha/issues/new/choose) so that we can discuss the implementation with you before you proceed with the work.
 
-You can review our [contribution guide](_about/CONTRIBUTING.md) to begin. You can also check out our [frequently asked questions](_about/FAQ.md).
+You can review our [contribution guide](https://github.com/hashicorp/terraform-provider-kubernetes-alpha/_about/CONTRIBUTING.md) to begin. You can also check out our [frequently asked questions](https://github.com/hashicorp/terraform-provider-kubernetes-alpha/_about/FAQ.md).


### PR DESCRIPTION
Add full URLs so that links aren't broken when README is vaccumed up by registry. Also updates README installation instructions. Relates to #58 

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Acceptance tests
- [ ] Have you added an acceptance test for the functionality being added?
- [ ] Have you run the acceptance tests on this branch? (If so, please include the test log in a gist)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
