### PR TITLE
Fix login with username and password

### DIFF
--- a/provider/server.go
+++ b/provider/server.go
@@ -372,7 +372,7 @@ func (s *RawProviderServer) Configure(ctx context.Context, req *tfplugin5.Config
 		password = providerConfig.GetAttr("password")
 	}
 	if !password.IsNull() {
-		overrides.AuthInfo.Username = password.AsString()
+		overrides.AuthInfo.Password = password.AsString()
 	}
 
 	var token cty.Value


### PR DESCRIPTION
### Description

When initializing the provider with username and password I received an "Unauthorized" error. Checking the log (dev.log) I noticed that the "Password" field was blank.

Setting the correct value AuthInfo value in "provider/server.go" should fix this problem.