### PR TITLE
Add standalone process debug mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,11 +8,16 @@ import (
 )
 
 func main() {
+	var dFlag = flag.Bool("debug", false, "run the provider in re-attach mode")
 	flag.Parse()
 
 	defer provider.InitDevLog()()
 
 	provider.Dlog.Printf("Starting up with command line: %#v\n", os.Args)
 
-	provider.Serve()
+	if *dFlag {
+		provider.DebugServe()
+	} else {
+		provider.Serve()
+	}
 }

--- a/provider/plugin.go
+++ b/provider/plugin.go
@@ -126,21 +126,6 @@ func waitForReattachConfig(ch chan *plugin.ReattachConfig) {
 	}
 }
 
-// ReattachConfig holds the information Terraform needs to be able to attach
-// itself to a provider process, so it can drive the process.
-type ReattachConfig struct {
-	Protocol string
-	Pid      int
-	Test     bool
-	Addr     ReattachConfigAddr
-}
-
-// ReattachConfigAddr is a JSON-encoding friendly version of net.Addr.
-type ReattachConfigAddr struct {
-	Network string
-	String  string
-}
-
 type grpcPlugin struct {
 	plugin.Plugin
 	providerServer *RawProviderServer

--- a/provider/plugin.go
+++ b/provider/plugin.go
@@ -104,7 +104,7 @@ func waitForReattachConfig(ch chan *plugin.ReattachConfig) {
 	select {
 	case config = <-ch:
 		reattachStr, err := json.Marshal(map[string]tfexec.ReattachConfig{
-			"hashicorp/kubernetes-alpha": tfexec.ReattachConfig{
+			"hashicorp/kubernetes-alpha": {
 				Protocol: string(config.Protocol),
 				Pid:      config.Pid,
 				Test:     config.Test,

--- a/provider/plugin.go
+++ b/provider/plugin.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -19,7 +20,7 @@ var handshakeConfig = plugin.HandshakeConfig{
 	MagicCookieValue: "d602bf8f470bc67ca7faa0386276bbdd4330efaf76d1a219cb4d6991ca9872b2",
 }
 
-// Serve is the provider entry point
+// Serve is the default provider entry point
 func Serve() {
 	plugin.Serve(&plugin.ServeConfig{
 		HandshakeConfig: handshakeConfig,
@@ -72,6 +73,72 @@ func ServeTest() (tfexec.ReattachInfo, error) {
 	case <-time.After(10 * time.Second):
 		return nil, fmt.Errorf("timeout when starting the provider")
 	}
+}
+
+// DebugServe is the provider entry point when running in stand-alone process mode
+func DebugServe() {
+	reattachCh := make(chan *plugin.ReattachConfig)
+
+	go waitForReattachConfig(reattachCh)
+
+	plugin.Serve(&plugin.ServeConfig{
+		HandshakeConfig: handshakeConfig,
+		GRPCServer:      plugin.DefaultGRPCServer,
+		Plugins: plugin.PluginSet{
+			"provider": &grpcPlugin{
+				providerServer: &RawProviderServer{},
+			},
+		},
+		Test: &plugin.ServeTestConfig{
+			ReattachConfigCh: reattachCh,
+		},
+		Logger: hclog.FromStandardLogger(Dlog, &hclog.LoggerOptions{
+			JSONFormat: false,
+			Level:      hclog.Debug,
+		}),
+	})
+}
+
+func waitForReattachConfig(ch chan *plugin.ReattachConfig) {
+	var config *plugin.ReattachConfig
+	select {
+	case config = <-ch:
+		reattachStr, err := json.Marshal(map[string]tfexec.ReattachConfig{
+			"hashicorp/kubernetes-alpha": tfexec.ReattachConfig{
+				Protocol: string(config.Protocol),
+				Pid:      config.Pid,
+				Test:     config.Test,
+				Addr: tfexec.ReattachConfigAddr{
+					String:  config.Addr.String(),
+					Network: config.Addr.Network(),
+				},
+			},
+		})
+		if err != nil {
+			fmt.Printf("Error building reattach string: %s", err)
+			return
+		}
+		fmt.Printf("# Provider server started\nexport TF_REATTACH_PROVIDERS='%s'\n", string(reattachStr))
+		return
+	case <-time.After(2 * time.Second):
+		fmt.Printf("Timeout while waiting for reattach configuration\n")
+		return
+	}
+}
+
+// ReattachConfig holds the information Terraform needs to be able to attach
+// itself to a provider process, so it can drive the process.
+type ReattachConfig struct {
+	Protocol string
+	Pid      int
+	Test     bool
+	Addr     ReattachConfigAddr
+}
+
+// ReattachConfigAddr is a JSON-encoding friendly version of net.Addr.
+type ReattachConfigAddr struct {
+	Network string
+	String  string
 }
 
 type grpcPlugin struct {


### PR DESCRIPTION
### Description

This change adds a command line argument to the provider binary to allow it to start in stand-alone mode and let Terraform connect to it during operations. This allows for easier debugging as one can attach a debugger to the provider process.

To start the provider in debug mode, run the provider binary with the `-debug` command line argument.
It should output a command that exports and environment variable, like so:
```
# Provider server started
export TF_REATTACH_PROVIDERS='{"hashicorp/kubernetes-alpha":{"Protocol":"grpc","Pid":22668,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/t7/z1g1xbgn4qzd6pck7d_s1zxh0000gn/T/plugin352167827"}}}'
```

To use the provider, copy the `export` statement and paste it in the shell session where you want to run `terraform`. You will then be able to run `terraform init` and Terraform should find the already running provider and not download it from the registry.

Every time the provider process is restarted, the environment variable needs to be updated from the output of the new provider process.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Add stand-alone debug mode for attaching debuggers to provider process.
```
