### PR TITLE
Tidy up reattach code

### DIFF
--- a/.github/workflows/check_examples.yaml
+++ b/.github/workflows/check_examples.yaml
@@ -26,7 +26,6 @@ jobs:
         go-version: ${{ steps.go-version.outputs.content }}
     - uses: engineerd/setup-kind@v0.3.0
     - name: Check examples run
-      run: ./scripts/check_examples.sh
+      run: make check-examples
       env:
         TERM: xterm-256color
-      shell: bash

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -47,6 +47,9 @@ fmtcheck:
 errcheck:
 	@sh -c "'$(CURDIR)/scripts/errcheck.sh'"
 
+check-examples: build
+	@sh -c "'$(CURDIR)/scripts/check_examples.sh'"
+
 test-compile:
 	@if [ "$(TEST)" = "./..." ]; then \
 		echo "ERROR: Set TEST to a specific package. For example,"; \
@@ -54,6 +57,8 @@ test-compile:
 		exit 1; \
 	fi
 	go test -c $(TEST) $(TESTARGS)
+
+
 
 website:
 ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))

--- a/main.go
+++ b/main.go
@@ -8,15 +8,14 @@ import (
 )
 
 func main() {
-	var dFlag = flag.Bool("debug", false, "run the provider in re-attach mode")
+	var debug = flag.Bool("debug", false, "run the provider in re-attach mode")
 	flag.Parse()
 
 	defer provider.InitDevLog()()
 
 	provider.Dlog.Printf("Starting up with command line: %#v\n", os.Args)
-
-	if *dFlag {
-		provider.DebugServe()
+	if *debug {
+		provider.ServeReattach()
 	} else {
 		provider.Serve()
 	}

--- a/scripts/check_examples.sh
+++ b/scripts/check_examples.sh
@@ -2,11 +2,16 @@
 
 set -e
 
-export TF_IN_AUTOMATION=true
+TF_IN_AUTOMATION=true
+TF_PLUGIN_VERSION="99.0.0"
+TF_PLUGIN_BINARY_NAME="terraform-provider-kubernetes-alpha"
+TF_PLUGIN_BINARY_PATH=".plugins/registry.terraform.io/hashicorp/kubernetes-alpha/$TF_PLUGIN_VERSION/$(go env GOOS)_$(go env GOARCH)/"
 
-if [ ! -f ./terraform-provider-kubernetes-alpha ]; then
-    make build
+if [ ! -f $TF_PLUGIN_BINARY_PATH ]; then
+    mkdir -p $TF_PLUGIN_BINARY_PATH
 fi
+
+cp ./terraform-provider-kubernetes-alpha $TF_PLUGIN_BINARY_PATH
 
 SKIP_CHECKS=.skip_checks
 for example in $PWD/examples/*; do
@@ -16,12 +21,11 @@ for example in $PWD/examples/*; do
         echo "$SKIP_CHECKS specified. Skipping this example."
         continue
     fi
-    terraform init -plugin-dir ../..
+    terraform init -plugin-dir ../../.plugins
     terraform validate
     terraform plan -out tfplan > /dev/null
     terraform apply tfplan
     terraform refresh
     terraform destroy -auto-approve
     echo
-    
 done

--- a/test/acceptance/acceptance_test.go
+++ b/test/acceptance/acceptance_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -27,7 +28,7 @@ var reattachInfo tfexec.ReattachInfo
 func TestMain(m *testing.M) {
 	provider.InitDevLog()
 	var err error
-	reattachInfo, err = provider.ServeTest()
+	reattachInfo, err = provider.ServeTest(context.TODO())
 	if err != nil {
 		//lintignore:R009
 		panic(err)


### PR DESCRIPTION
### Description

This tidies up the reattach code so there is less duplication.

I have also fixed the check examples script and added a `check-examples` target to the Makefile.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
