### PR TITLE
Update vault example

### DIFF
--- a/examples/vault/injector.tf
+++ b/examples/vault/injector.tf
@@ -99,7 +99,7 @@ resource "kubernetes_manifest" "service-injector" {
         },
       ]
       "selector" = {
-        "app.kubernetes.io/instance" = "${var.name}"
+        "app.kubernetes.io/instance" = var.name
         "app.kubernetes.io/name"     = "vault-agent-injector"
         "component"                  = "webhook"
       }

--- a/examples/vault/main.tf
+++ b/examples/vault/main.tf
@@ -1,4 +1,9 @@
+variable "server_side_planning" {
+  type = bool
+  default = false
+}
+
 provider "kubernetes-alpha" {
-  config_file          = var.kubeconfig
-  server_side_planning = true
+  server_side_planning = var.server_side_planning
+  config_path          = var.kubeconfig
 }

--- a/examples/vault/webhook.tf
+++ b/examples/vault/webhook.tf
@@ -5,7 +5,7 @@ resource "kubernetes_manifest" "webhook-injector" {
     "kind"       = "MutatingWebhookConfiguration"
     "metadata" = {
       "labels" = {
-        "app.kubernetes.io/instance"   = "${var.name}"
+        "app.kubernetes.io/instance"   = var.name
         "app.kubernetes.io/managed-by" = "Terraform"
         "app.kubernetes.io/name"       = "vault-agent-injector"
       }


### PR DESCRIPTION
Update provider block and remove interpolation-only syntax.

### Description

Minor fixes to correct errors seen during `apply`.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Update vault example to fix `apply` errors.
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
