### PR TITLE
Remove namespace from non-namespaced resources

### DIFF
--- a/examples/vault/injector.tf
+++ b/examples/vault/injector.tf
@@ -59,7 +59,6 @@ resource "kubernetes_manifest" "cluster-role-binding-injector" {
         "app.kubernetes.io/name"       = "vault-agent-injector"
       }
       "name"      = "${var.name}-vault-agent-injector-binding"
-      "namespace" = var.namespace
     }
     "roleRef" = {
       "apiGroup" = "rbac.authorization.k8s.io"

--- a/examples/vault/server.tf
+++ b/examples/vault/server.tf
@@ -35,7 +35,6 @@ resource "kubernetes_manifest" "cluster-role-binding-server" {
         "app.kubernetes.io/name"       = "vault"
       }
       "name"      = "${var.name}-vault-server-binding"
-      "namespace" = var.namespace
     }
     "roleRef" = {
       "apiGroup" = "rbac.authorization.k8s.io"


### PR DESCRIPTION
This allows the vault example to successfully apply using a pre-released version of terraform (at commit 55e6f64977b) and the `local-plan` branch of this repo.

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
