### PR TITLE
Fix wait

### DIFF
--- a/provider/apply.go
+++ b/provider/apply.go
@@ -184,9 +184,12 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 			return resp, fmt.Errorf("failed to determine resource type ID: %s", err)
 		}
 
-		err = s.waitForCompletion(ctx, applyPlannedState, rs, rname, wt)
-		if err != nil {
-			return resp, err
+		wf, ok := plannedStateVal["wait_for"]
+		if ok {
+			err = s.waitForCompletion(ctx, wf, rs, rname, wt)
+			if err != nil {
+				return resp, err
+			}
 		}
 
 		compObj, err := morph.DeepUnknown(tsch, newResObject, tftypes.AttributePath{})
@@ -272,9 +275,12 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 			return resp, fmt.Errorf("failed to determine resource type ID: %s", err)
 		}
 
-		err = s.waitForCompletion(ctx, priorStateVal["wait_for"], rs, rname, wt)
-		if err != nil {
-			return resp, err
+		wf, ok := priorStateVal["wait_for"]
+		if ok {
+			err = s.waitForCompletion(ctx, wf, rs, rname, wt)
+			if err != nil {
+				return resp, err
+			}
 		}
 
 		resp.NewState = req.PlannedState

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -89,12 +89,13 @@ func (ps *RawProviderServer) TFTypeFromOpenAPI(gvk schema.GroupVersionKind, stat
 	// remove "status" attribute from resource type
 	if tsch.Is(tftypes.Object{}) && !status {
 		ot := tsch.(tftypes.Object)
-		_, ok := ot.AttributeTypes["status"]
-		if ok {
-			atts := ot.AttributeTypes
-			delete(atts, "status")
-			tsch = tftypes.Object{AttributeTypes: atts}
+		atts := make(map[string]tftypes.Type)
+		for k, t := range ot.AttributeTypes {
+			if k != "status" {
+				atts[k] = t
+			}
 		}
+		tsch = tftypes.Object{AttributeTypes: atts}
 	}
 
 	return tsch, nil


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
This change fixes an issue where the `wait_for` logic wasn't getting access to the contents of the "status" attribute in a resource. This was a regression introduced during the re-factoring to the new SDK.

Waiting on "status" contents should be possible after this change.
### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
