### PR TITLE
Check min Terraform version used to call the provider

### DIFF
--- a/provider/configure.go
+++ b/provider/configure.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tftypes"
 	"github.com/mitchellh/go-homedir"
+	"golang.org/x/mod/semver"
 	"k8s.io/apimachinery/pkg/runtime"
 	apimachineryschema "k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -23,12 +24,23 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
+const minTFVersion string = "v0.14.8"
+
 // ConfigureProvider function
 func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov5.ConfigureProviderRequest) (*tfprotov5.ConfigureProviderResponse, error) {
 	response := &tfprotov5.ConfigureProviderResponse{}
 	diags := []*tfprotov5.Diagnostic{}
 	var providerConfig map[string]tftypes.Value
 	var err error
+
+	if semver.IsValid("v"+req.TerraformVersion) && semver.Compare("v"+req.TerraformVersion, minTFVersion) < 0 {
+		response.Diagnostics = append(response.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Terraform version too old",
+			Detail:   fmt.Sprintf("This provider requires a Terraform version starting at %s and above", minTFVersion),
+		})
+		return response, nil
+	}
 
 	// transform provider config schema into tftype.Type and unmarshal the given config into a tftypes.Value
 	cfgType := GetTypeFromSchema(GetProviderConfigSchema())

--- a/provider/configure.go
+++ b/provider/configure.go
@@ -37,7 +37,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 		response.Diagnostics = append(response.Diagnostics, &tfprotov5.Diagnostic{
 			Severity: tfprotov5.DiagnosticSeverityError,
 			Summary:  "Incompatible terraform version",
-			Detail:   fmt.Sprintf("This provider requires a Terraform version starting at %s and above", minTFVersion),
+			Detail:   fmt.Sprintf("This provider requires Terraform %s or above", minTFVersion),
 		})
 		return response, nil
 	}

--- a/provider/configure.go
+++ b/provider/configure.go
@@ -36,7 +36,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 	if semver.IsValid("v"+req.TerraformVersion) && semver.Compare("v"+req.TerraformVersion, minTFVersion) < 0 {
 		response.Diagnostics = append(response.Diagnostics, &tfprotov5.Diagnostic{
 			Severity: tfprotov5.DiagnosticSeverityError,
-			Summary:  "Terraform version too old",
+			Summary:  "Incompatible terraform version",
 			Detail:   fmt.Sprintf("This provider requires a Terraform version starting at %s and above", minTFVersion),
 		})
 		return response, nil


### PR DESCRIPTION
### Description

This change introduces a check for the minimum Terraform version required to run the provider reliably.

When used with an earlier version than 0.14.8, the provider will throw the following error:
```
» terraform plan                                                                                                          alex@Alexs-MBP

Error: Terraform version too old

  on namespace.tf line 1, in provider "kubernetes-alpha":
   1: provider "kubernetes-alpha" {

This provider requires a Terrafrom version starting at v0.14.8 and above

-----------------------------------------------------------------------
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS:
* provider will now throw an error when used with a Terraform version older than 0.14.8
```
### References
Fixes #160 

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
