### PR TITLE
Parse token in correct variable & return diagnostics not errors

### DIFF
--- a/provider/configure.go
+++ b/provider/configure.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/pem"
 	"errors"
-	"fmt"
 	"net/url"
 	"os"
 	"strconv"
@@ -39,7 +38,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 			Summary:  "Failed to decode ConfigureProvider request parameter",
 			Detail:   err.Error(),
 		})
-		return response, err
+		return response, nil
 	}
 	err = cfgVal.As(&providerConfig)
 	if err != nil {
@@ -49,7 +48,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 			Summary:  "Provider configuration: failed to extract 'config_path' value",
 			Detail:   err.Error(),
 		})
-		return response, err
+		return response, nil
 	}
 
 	overrides := &clientcmd.ConfigOverrides{}
@@ -67,7 +66,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 				Summary:  "Provider configuration: failed to extract 'config_path' value",
 				Detail:   err.Error(),
 			})
-			return response, err
+			return response, nil
 		}
 	}
 	// check environment - this overrides any value found in provider configuration
@@ -100,7 +99,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 				Summary:  "Invalid attribute in provider configuration",
 				Detail:   "'client_certificate' type cannot be asserted: " + err.Error(),
 			})
-			return response, err
+			return response, nil
 		}
 	}
 	if clientCrtEnv, ok := os.LookupEnv("KUBE_CLIENT_CERT_DATA"); ok && clientCrtEnv != "" {
@@ -130,7 +129,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 				Summary:  "Provider configuration: failed to extract 'cluster_ca_certificate' value",
 				Detail:   err.Error(),
 			})
-			return response, err
+			return response, nil
 		}
 	}
 	if clusterCAEnv, ok := os.LookupEnv("KUBE_CLUSTER_CA_CERT_DATA"); ok && clusterCAEnv != "" {
@@ -160,7 +159,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 				Summary:  "Provider configuration: failed to assert type of 'insecure' value",
 				Detail:   err.Error(),
 			})
-			return response, err
+			return response, nil
 		}
 	}
 	if insecureEnv, ok := os.LookupEnv("KUBE_INSECURE"); ok && insecureEnv != "" {
@@ -193,7 +192,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 				Summary:  "Provider configuration: failed to extract 'host' value",
 				Detail:   err.Error(),
 			})
-			return response, err
+			return response, nil
 		}
 	}
 	// check environment - this overrides any value found in provider configuration
@@ -216,7 +215,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 				Summary:  "Invalid attribute in provider configuration",
 				Detail:   "Invalid value for 'host': " + err.Error(),
 			})
-			return response, err
+			return response, nil
 		}
 		// Server has to be the complete address of the kubernetes cluster (scheme://hostname:port), not just the hostname,
 		// because `overrides` are processed too late to be taken into account by `defaultServerUrlFor()`.
@@ -237,7 +236,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 				Summary:  "Provider configuration: ",
 				Detail:   "Failed to extract 'client_key' value" + err.Error(),
 			})
-			return response, err
+			return response, nil
 		}
 	}
 	// check environment - this overrides any value found in provider configuration
@@ -258,7 +257,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 
 	if len(diags) > 0 {
 		response.Diagnostics = diags
-		return response, errors.New("failed to validate provider configuration")
+		return response, nil
 	}
 
 	// Handle 'config_context' attribute
@@ -273,7 +272,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 				Summary:  "Provider configuration: failed to assert type of 'config_context' value",
 				Detail:   err.Error(),
 			})
-			return response, err
+			return response, nil
 		}
 		overrides.CurrentContext = cfgContext
 	}
@@ -295,7 +294,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 				Summary:  "Provider configuration: failed to assert type of 'config_context_cluster' value",
 				Detail:   err.Error(),
 			})
-			return response, err
+			return response, nil
 		}
 		overrides.Context.Cluster = cfgCtxCluster
 	}
@@ -315,7 +314,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 				Summary:  "Provider configuration: failed to assert type of 'config_context_user' value",
 				Detail:   err.Error(),
 			})
-			return response, err
+			return response, nil
 		}
 		if cfgContextAuthInfo != nil {
 			overrides.Context.AuthInfo = *cfgContextAuthInfo
@@ -335,7 +334,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 				Summary:  "Provider configuration: failed to assert type of 'username' value",
 				Detail:   err.Error(),
 			})
-			return response, err
+			return response, nil
 		}
 		overrides.AuthInfo.Username = username
 	}
@@ -345,7 +344,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 
 	var password string
 	if !providerConfig["password"].IsNull() && providerConfig["password"].IsKnown() {
-		err = providerConfig["username"].As(&password)
+		err = providerConfig["password"].As(&password)
 		if err != nil {
 			// invalid attribute type - this shouldn't happen, bail out for now
 			response.Diagnostics = append(response.Diagnostics, &tfprotov5.Diagnostic{
@@ -353,7 +352,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 				Summary:  "Provider configuration: failed to assert type of 'password' value",
 				Detail:   err.Error(),
 			})
-			return response, err
+			return response, nil
 		}
 		overrides.AuthInfo.Password = password
 	}
@@ -363,7 +362,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 
 	var token string
 	if !providerConfig["token"].IsNull() && providerConfig["token"].IsKnown() {
-		err = providerConfig["token"].As(&password)
+		err = providerConfig["token"].As(&token)
 		if err != nil {
 			// invalid attribute type - this shouldn't happen, bail out for now
 			response.Diagnostics = append(response.Diagnostics, &tfprotov5.Diagnostic{
@@ -371,7 +370,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 				Summary:  "Provider configuration: failed to assert type of 'token' value",
 				Detail:   err.Error(),
 			})
-			return response, err
+			return response, nil
 		}
 		overrides.AuthInfo.Token = token
 	}
@@ -390,7 +389,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 				Summary:  "Provider configuration: failed to assert type of 'exec' value",
 				Detail:   err.Error(),
 			})
-			return response, err
+			return response, nil
 		}
 		execCfg := clientcmdapi.ExecConfig{}
 		if !execObj["api_version"].IsNull() && execObj["api_version"].IsKnown() {
@@ -403,7 +402,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 					Summary:  "Provider configuration: failed to assert type of 'api_version' value",
 					Detail:   err.Error(),
 				})
-				return response, err
+				return response, nil
 			}
 			execCfg.APIVersion = apiv
 		}
@@ -417,7 +416,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 					Summary:  "Provider configuration: failed to assert type of 'command' value",
 					Detail:   err.Error(),
 				})
-				return response, err
+				return response, nil
 			}
 			execCfg.Command = cmd
 		}
@@ -431,7 +430,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 					Summary:  "Provider configuration: failed to assert type of 'args' value",
 					Detail:   err.Error(),
 				})
-				return response, err
+				return response, nil
 			}
 			execCfg.Args = make([]string, 0, len(xcmdArgs))
 			for _, arg := range xcmdArgs {
@@ -444,7 +443,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 						Summary:  "Provider configuration: failed to assert type of element in 'args' value",
 						Detail:   err.Error(),
 					})
-					return response, err
+					return response, nil
 				}
 				execCfg.Args = append(execCfg.Args, v)
 			}
@@ -459,7 +458,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 					Summary:  "Provider configuration: failed to assert type of element in 'env' value",
 					Detail:   err.Error(),
 				})
-				return response, err
+				return response, nil
 			}
 			execCfg.Env = make([]clientcmdapi.ExecEnvVar, 0, len(xcmdEnvs))
 			for k, v := range xcmdEnvs {
@@ -472,7 +471,7 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 						Summary:  "Provider configuration: failed to assert type of element in 'env' value",
 						Detail:   err.Error(),
 					})
-					return response, err
+					return response, nil
 				}
 				execCfg.Env = append(execCfg.Env, clientcmdapi.ExecEnvVar{
 					Name:  k,
@@ -492,7 +491,12 @@ func (s *RawProviderServer) ConfigureProvider(ctx context.Context, req *tfprotov
 			// this is a terrible fix for if the configuration is a calculated value
 			return response, nil
 		}
-		return response, fmt.Errorf("cannot load Kubernetes client config: %s", err)
+		response.Diagnostics = append(response.Diagnostics, &tfprotov5.Diagnostic{
+			Severity: tfprotov5.DiagnosticSeverityError,
+			Summary:  "Provider configuration: cannot load Kubernetes client config",
+			Detail:   err.Error(),
+		})
+		return response, nil
 	}
 
 	if s.logger.IsTrace() {


### PR DESCRIPTION
### Description
This change fixes a few copy-paste errors in the provider configuration processing that resulted in `token`, `username` and `password` attributes not being handled correctly.

A side effect of this misconfiguration seems to have caused infinite request retrying on the discovery API.

This also changes the return statements in `ConfigureProvider` to not return an error when diagnostics are set. Returning an error would prevent the diagnostics from being displayed by Terraform.

<!--- Please leave a helpful description of the pull request here. --->

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUGFIXES:
* fix handling of `token`, `username` and `password` attributes in the provider configuration (#162)
* fix infinite retries on discovery API with invalid credentials (#159)
```
### References
Fixes #162
Fixes #159 

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
