### PR TITLE
Don't fail validation when manifest contains unknown values

### DIFF
--- a/provider/validate.go
+++ b/provider/validate.go
@@ -62,6 +62,11 @@ func (s *RawProviderServer) ValidateResourceTypeConfig(ctx context.Context, req 
 	rawManifest := make(map[string]tftypes.Value)
 	err = manifest.As(&rawManifest)
 	if err != nil {
+		if err.Error() == "unmarshaling unknown values is not supported" {
+			// likely this validation call came to early and the manifest still contains unknown values
+			// bailing out witout error to allow the resource to be completed at a later stage
+			return resp, nil
+		}
 		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
 			Severity:  tfprotov5.DiagnosticSeverityError,
 			Summary:   `Failed to extract "manifest" attribute value from resource configuration`,

--- a/provider/validate.go
+++ b/provider/validate.go
@@ -63,8 +63,8 @@ func (s *RawProviderServer) ValidateResourceTypeConfig(ctx context.Context, req 
 	err = manifest.As(&rawManifest)
 	if err != nil {
 		if err.Error() == "unmarshaling unknown values is not supported" {
-			// likely this validation call came to early and the manifest still contains unknown values
-			// bailing out witout error to allow the resource to be completed at a later stage
+			// Likely this validation call came too early and the manifest still contains unknown values.
+			// Bailing out without error to allow the resource to be completed at a later stage.
 			return resp, nil
 		}
 		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{


### PR DESCRIPTION
### Description

This change relaxes an error check during validation to accomodate for situations where attribute values can be unknown at this point.
Throwing an error here will prevent an eventually valid resource to reach the processing step where interpolations are resolved.

One particular situation that leads to this is when attribute values are set via Terraform's buit-in functions, which are evaluated later than ValidateResourceTypeConfig.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Don't fail validation when manifest contains unkown values (#169)
```
### References
Fixes #169

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
