### PR TITLE
Adapt github workflow to use new .go-version file name

### DIFF
--- a/.github/workflows/acceptance_tests.yaml
+++ b/.github/workflows/acceptance_tests.yaml
@@ -23,7 +23,7 @@ jobs:
         id: go-version
         uses: juliangruber/read-file-action@v1
         with:
-          path: ./go-version
+          path: ./.go-version
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/check_examples.yaml
+++ b/.github/workflows/check_examples.yaml
@@ -25,7 +25,7 @@ jobs:
         id: go-version
         uses: juliangruber/read-file-action@v1
         with:
-          path: ./go-version
+          path: ./.go-version
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -21,7 +21,7 @@ jobs:
         id: go-version
         uses: juliangruber/read-file-action@v1
         with:
-          path: ./go-version
+          path: ./.go-version
       - name: Set up Go
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
### Description

This file had to be renamed to accommodate the release process, but I omitted to update these workflows on that occasions.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
