### PR TITLE
Do API request to validate access before plan

### DIFF
--- a/provider/plan.go
+++ b/provider/plan.go
@@ -14,6 +14,12 @@ import (
 func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfprotov5.PlanResourceChangeRequest) (*tfprotov5.PlanResourceChangeResponse, error) {
 	resp := &tfprotov5.PlanResourceChangeResponse{}
 
+	// test if credentials are valid - we're going to need them further down
+	resp.Diagnostics = append(resp.Diagnostics, s.checkValidCredentials(ctx)...)
+	if len(resp.Diagnostics) > 0 {
+		return resp, nil
+	}
+
 	rt, err := GetResourceType(req.TypeName)
 	if err != nil {
 		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{


### PR DESCRIPTION
### Description

This change introduces a check for valid credentials at the beginning of plan. This is to ensure that users get a clear meaningful error message rather than a raw error from the API.
If credentials are invalid but the API is otherwise accessible the users will get this message:
```
Error: Invalid credentials

  on main.tf line 5, in resource "kubernetes_manifest" "test-configmap":
   5: resource "kubernetes_manifest" "test-configmap" {

The credentials configured in the provider block are not accepted by the API
server. Error: Unauthorized

Set TF_LOG=debug and look for '[InvalidClientConfiguration]' in the log to see
actual configuration.
```

The check is performed by doing a simple GET call on the API endpoint using the path `/apis` which only responds to authenticated calls but otherwise doesn't require specific permissions like resource paths do.

This also avoids the problem reported in #159 where the cached RESTMapper will get stuck in retry loop when credentials are invalid.

<!--- Please leave a helpful description of the pull request here. --->

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* checks credentials against the API at plan time and avoid infinite retry loop (#159)
```
### References

Fixes #159

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
