### PR TITLE
Bump terraform-plugin-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/hcl/v2 v2.9.0
 	github.com/hashicorp/terraform-exec v0.13.0
 	github.com/hashicorp/terraform-json v0.8.0
-	github.com/hashicorp/terraform-plugin-go v0.2.1
+	github.com/hashicorp/terraform-plugin-go v0.2.2-0.20210322135653-4adb0989fd88
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.4
 	github.com/hashicorp/terraform-plugin-test/v2 v2.1.3
 	github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce // indirect
@@ -32,5 +32,3 @@ require (
 	k8s.io/apimachinery v0.20.0
 	k8s.io/client-go v0.20.0
 )
-
-replace github.com/hashicorp/terraform-plugin-go => github.com/alexsomesan/terraform-plugin-go v0.2.2-0.20210220105816-6d52ca73d2f9 // TODO: Remove once https://github.com/hashicorp/terraform-plugin-go/pull/58 is merged

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,6 @@ github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4Rq
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alexsomesan/terraform-plugin-go v0.2.2-0.20210220105816-6d52ca73d2f9 h1:AtJZ41TwmMBVoBfv4bFcszJn946FRPJ1MW/6IRXUGrQ=
-github.com/alexsomesan/terraform-plugin-go v0.2.2-0.20210220105816-6d52ca73d2f9/go.mod h1:10V6F3taeDWVAoLlkmArKttR3IULlRWFAGtQIQTIDr4=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/crlf v0.0.0-20171020200849-670099aa064f/go.mod h1:k8feO4+kXDxro6ErPXBRTJ/ro2mf0SsFG8s7doP9kJE=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
@@ -339,6 +337,9 @@ github.com/hashicorp/terraform-exec v0.13.0/go.mod h1:SGhto91bVRlgXQWcJ5znSz+29U
 github.com/hashicorp/terraform-json v0.5.0/go.mod h1:eAbqb4w0pSlRmdvl8fOyHAi/+8jnkVYN28gJkSJrLhU=
 github.com/hashicorp/terraform-json v0.8.0 h1:XObQ3PgqU52YLQKEaJ08QtUshAfN3yu4u8ebSW0vztc=
 github.com/hashicorp/terraform-json v0.8.0/go.mod h1:3defM4kkMfttwiE7VakJDwCd4R+umhSQnvJwORXbprE=
+github.com/hashicorp/terraform-plugin-go v0.2.1/go.mod h1:10V6F3taeDWVAoLlkmArKttR3IULlRWFAGtQIQTIDr4=
+github.com/hashicorp/terraform-plugin-go v0.2.2-0.20210322135653-4adb0989fd88 h1:/+O4DGW/e5fkoDWzoxAWOph/jvpVTniQqxPv+QGlPZg=
+github.com/hashicorp/terraform-plugin-go v0.2.2-0.20210322135653-4adb0989fd88/go.mod h1:dFHsQMaTLpON2gWhVWT96fvtlc/MF1vSy3OdMhWBzdM=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.4 h1:6k0WcxFgVqF/GUFHPvAH8FIrCkoA1RInXzSxhkKamPg=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.4/go.mod h1:z+cMZ0iswzZOahBJ3XmNWgWkVnAd2bl8g+FhyyuPDH4=
 github.com/hashicorp/terraform-plugin-test/v2 v2.1.3 h1:sMsxHctzjATk+ICHAqiHFqLkjosl4fjMyFxMthLRH2Q=

--- a/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/server/doc.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/server/doc.go
@@ -1,4 +1,4 @@
-// Package tf5server implementations a server implementation for running
+// Package tf5server implements a server implementation to run
 // tfprotov5.ProviderServers as gRPC servers.
 //
 // Providers will likely be calling tf5server.Serve from their main function to

--- a/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/tftypes/attribute_path.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/tftypes/attribute_path.go
@@ -57,29 +57,9 @@ func (a AttributePath) Equal(o AttributePath) bool {
 	}
 	for pos, aStep := range a.Steps {
 		oStep := o.Steps[pos]
-		switch aVal := aStep.(type) {
-		case AttributeName:
-			oVal, ok := oStep.(AttributeName)
-			if !ok {
-				return false
-			}
-			if oVal != aVal {
-				return false
-			}
-		case ElementKeyString:
-			oVal, ok := oStep.(ElementKeyString)
-			if !ok {
-				return false
-			}
-			if oVal != aVal {
-				return false
-			}
-		case ElementKeyInt:
-			oVal, ok := oStep.(ElementKeyInt)
-			if !ok {
-				return false
-			}
-			if oVal != aVal {
+		switch aStep.(type) {
+		case AttributeName, ElementKeyString, ElementKeyInt:
+			if oStep != aStep {
 				return false
 			}
 		case ElementKeyValue:
@@ -87,11 +67,7 @@ func (a AttributePath) Equal(o AttributePath) bool {
 			if !ok {
 				return false
 			}
-			diffs, err := Value(aVal).Diff(Value(oVal))
-			if err != nil {
-				panic(err)
-			}
-			if len(diffs) > 0 {
+			if !Value(aStep.(ElementKeyValue)).Equal(Value(oVal)) {
 				return false
 			}
 		default:
@@ -295,6 +271,9 @@ type interfaceSliceAttributePathStepper []interface{}
 func (i interfaceSliceAttributePathStepper) ApplyTerraform5AttributePathStep(step AttributePathStep) (interface{}, error) {
 	eki, isElementKeyInt := step.(ElementKeyInt)
 	if !isElementKeyInt {
+		return nil, ErrInvalidStep
+	}
+	if eki < 0 {
 		return nil, ErrInvalidStep
 	}
 	// slices can only have items up to the max value of int

--- a/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/tftypes/value.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/tftypes/value.go
@@ -170,6 +170,9 @@ func (val Value) ApplyTerraform5AttributePathStep(step AttributePathStep) (inter
 		if !val.Type().Is(List{}) && !val.Type().Is(Tuple{}) {
 			return nil, ErrInvalidStep
 		}
+		if int64(s) < 0 {
+			return nil, ErrInvalidStep
+		}
 		sl := []Value{}
 		err := val.As(&sl)
 		if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -148,7 +148,7 @@ github.com/hashicorp/terraform-exec/tfinstall
 # github.com/hashicorp/terraform-json v0.8.0
 ## explicit
 github.com/hashicorp/terraform-json
-# github.com/hashicorp/terraform-plugin-go v0.2.1 => github.com/alexsomesan/terraform-plugin-go v0.2.2-0.20210220105816-6d52ca73d2f9
+# github.com/hashicorp/terraform-plugin-go v0.2.2-0.20210322135653-4adb0989fd88
 ## explicit
 github.com/hashicorp/terraform-plugin-go/tfprotov5
 github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/fromproto
@@ -559,4 +559,3 @@ k8s.io/utils/pointer
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
-# github.com/hashicorp/terraform-plugin-go => github.com/alexsomesan/terraform-plugin-go v0.2.2-0.20210220105816-6d52ca73d2f9


### PR DESCRIPTION
### Description

This provider depends on changes in terraform-plugin-go which have been in PR for a while and we're so far resorted to aggregating them in a fork.

Now that those changes are merged, we should re-align to the main plugin-go repository as a dependency. Note that a release hasn't been cut with said changes yet so we have to vendor on the commit from the tip of `main` branch.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
N/A
```
### References
https://github.com/hashicorp/terraform-plugin-go/pull/58
https://github.com/hashicorp/terraform-plugin-go/pull/60
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
