### PR TITLE
Opportunistically accept unknown value types

### DIFF
--- a/morph/morph.go
+++ b/morph/morph.go
@@ -15,9 +15,6 @@ func ValueToType(v tftypes.Value, t tftypes.Type, p tftypes.AttributePath) (tfty
 	if v.IsNull() {
 		return v, nil
 	}
-	if !v.IsKnown() {
-		return v, p.NewErrorf("cannot morph value that isn't fully known")
-	}
 	switch {
 	case v.Type().Is(tftypes.String):
 		return morphStringToType(v, t, p)
@@ -37,6 +34,9 @@ func ValueToType(v tftypes.Value, t tftypes.Type, p tftypes.AttributePath) (tfty
 		return morphMapToType(v, t, p)
 	case v.Type().Is(tftypes.Object{}):
 		return morphObjectToType(v, t, p)
+	}
+	if !v.IsKnown() {
+		return v, p.NewErrorf("cannot morph value that isn't fully known")
 	}
 	return tftypes.Value{}, p.NewErrorf("[%s] unsupported morph from value: %v", p.String(), v)
 }


### PR DESCRIPTION
When morphing values from source to wireformat, which is uploaded to
Kubernetes, this plugin performs type coherence checking to ensure
you're not uploading "foo" into a field that expects a number.

Previously, if the value you were trying to pass was "Unknown", meaning
it was to be computed during the apply phase, you would get an error
about failing to morph from object element to object element. This is a
good error to have in place since it prevents the user from accidentally
passing an inappropriately typed value into the Kubernetes cluster and
doesn't even require communication with the cluster, making it decidable
very early in the execution flow.

This change modifies the algorithm to allow situations where you're not
dependent on type coercion to proceed. E.g. the "Unknown" value has a
known type that is compatible with the destination type and therefore it
doesn't matter what the value is for purposes of type compatibility.

It is still allowed to pass a string into a number if that value is
numeric, but only if that value is known at plan time.

Fixed: #190

### Release Note

```release-note
* Allow fields with known types but unknown values to be passed to `kubernetes_manifest` resources
```
### References

Issue #190

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
