### PR TITLE
Add service acceptance tests

### DIFF
--- a/test/acceptance/service_test.go
+++ b/test/acceptance/service_test.go
@@ -1,0 +1,77 @@
+// +build acceptance
+
+package acceptance
+
+import (
+	"testing"
+
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes-alpha/test/helper/state"
+)
+
+// This test case tests a Service but also is a demonstration of some the assert functions
+// available in the test helper
+func TestKubernetesManifest_Service(t *testing.T) {
+	name := randName()
+	namespace := randName()
+
+	tf := tfhelper.RequireNewWorkingDir(t)
+	tf.SetReattachInfo(reattachInfo)
+	defer func() {
+		tf.RequireDestroy(t)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "v1", "services", namespace, name)
+	}()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteNamespace(t, namespace)
+
+	tfvars := TFVARS{
+		"namespace": namespace,
+		"name":      name,
+	}
+	tfconfig := loadTerraformConfig(t, "Service/service.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+	tf.RequireApply(t)
+
+	k8shelper.AssertNamespacedResourceExists(t, "v1", "services", namespace, name)
+
+	tfstate := tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace":       namespace,
+		"kubernetes_manifest.test.object.metadata.name":            name,
+		"kubernetes_manifest.test.object.spec.ports[0].name":       "http",
+		"kubernetes_manifest.test.object.spec.ports[0].port":       "80",
+		"kubernetes_manifest.test.object.spec.ports[0].targetPort": "8080",
+		"kubernetes_manifest.test.object.spec.ports[0].protocol":   "TCP",
+		"kubernetes_manifest.test.object.spec.selector.app":        "test",
+		"kubernetes_manifest.test.object.spec.type":                "LoadBalancer",
+	})
+
+	tfconfigModified := loadTerraformConfig(t, "Service/service_modified.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfigModified)
+	tf.RequireApply(t)
+
+	tfstate = tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace":        namespace,
+		"kubernetes_manifest.test.object.metadata.name":             name,
+		"kubernetes_manifest.test.object.metadata.annotations.test": "1",
+		"kubernetes_manifest.test.object.metadata.labels.test":      "2",
+		"kubernetes_manifest.test.object.spec.ports[0].name":        "https",
+		"kubernetes_manifest.test.object.spec.ports[0].port":        "443",
+		"kubernetes_manifest.test.object.spec.ports[0].targetPort":  "8443",
+		"kubernetes_manifest.test.object.spec.ports[0].protocol":    "TCP",
+		"kubernetes_manifest.test.object.spec.selector.app":         "test",
+		"kubernetes_manifest.test.object.spec.type":                 "LoadBalancer",
+	})
+
+	// tfstate.AssertAttributeEqual(t, "kubernetes_manifest.test.object.data.fizz", "buzz")
+
+	tfstate.AssertAttributeLen(t, "kubernetes_manifest.test.object.metadata.labels", 1)
+	tfstate.AssertAttributeLen(t, "kubernetes_manifest.test.object.metadata.annotations", 1)
+
+	tfstate.AssertAttributeNotEmpty(t, "kubernetes_manifest.test.object.metadata.labels.test")
+
+	tfstate.AssertAttributeDoesNotExist(t, "kubernetes_manifest.test.spec")
+}

--- a/test/acceptance/testdata/Service/service.tf
+++ b/test/acceptance/testdata/Service/service.tf
@@ -1,0 +1,29 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Service"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+    }
+
+    spec = {
+      ports = [{
+        name       = "http",
+        port       = 80,
+        targetPort = 8080,
+        # Protcol is required for serverside apply per https://github.com/kubernetes-sigs/structured-merge-diff/issues/130
+        protocol = "TCP"
+      }]
+      selector = {
+        app = "test"
+      }
+      type = "LoadBalancer"
+    }
+  }
+}

--- a/test/acceptance/testdata/Service/service_modified.tf
+++ b/test/acceptance/testdata/Service/service_modified.tf
@@ -1,0 +1,35 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Service"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+      annotations = {
+        test = "1"
+      }
+      labels = {
+        test = "2"
+      }
+    }
+
+    spec = {
+      ports = [{
+        name       = "https",
+        port       = 443,
+        targetPort = 8443,
+        # Protcol is required for serverside apply per https://github.com/kubernetes-sigs/structured-merge-diff/issues/130
+        protocol = "TCP"
+      }]
+      selector = {
+        app = "test"
+      }
+      type = "LoadBalancer"
+    }
+  }
+}

--- a/test/acceptance/testdata/Service/variables.tf
+++ b/test/acceptance/testdata/Service/variables.tf
@@ -1,0 +1,16 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}


### PR DESCRIPTION
### Description

Currently the service test always fails, but on a random `spec.ports[0]` attribute each time.

e.g.
```
=== RUN   TestKubernetesManifest_Service
    service_test.go:40: "kubernetes_manifest.test.object.spec.ports[0].protocol" does not exist
--- FAIL: TestKubernetesManifest_Service (0.83s)
```

Attribute can be confirmed with `terraform state show kubernetes_manifest.test` and using `output` in Terraform. 

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
