### PR TITLE
Add support for non-structured custom resources

### DIFF
--- a/provider/apply.go
+++ b/provider/apply.go
@@ -173,7 +173,7 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 			return resp, nil
 		}
 
-		newResObject, err := payload.ToTFValue(FilterEphemeralFields(result.Object), tsch, tftypes.NewAttributePath())
+		newResObject, err := payload.ToTFValue(RemoveServerSideFields(result.Object), tsch, tftypes.NewAttributePath())
 		if err != nil {
 			return resp, err
 		}

--- a/provider/plan.go
+++ b/provider/plan.go
@@ -8,7 +8,73 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-provider-kubernetes-alpha/morph"
+	"github.com/hashicorp/terraform-provider-kubernetes-alpha/payload"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
 )
+
+func (s *RawProviderServer) dryRun(ctx context.Context, obj tftypes.Value) error {
+	c, err := s.getDynamicClient()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve Kubernetes dynamic client during apply: %v", err)
+	}
+	m, err := s.getRestMapper()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve Kubernetes RESTMapper client during apply: %v", err)
+	}
+
+	gvk, err := GVKFromTftypesObject(&obj, m)
+	if err != nil {
+		return fmt.Errorf("failed to determine resource GVK: %s", err)
+	}
+
+	minObj := morph.UnknownToNull(obj)
+	pu, err := payload.FromTFValue(minObj, tftypes.AttributePath{})
+	if err != nil {
+		return err
+	}
+
+	rqObj := mapRemoveNulls(pu.(map[string]interface{}))
+	uo := unstructured.Unstructured{}
+	uo.SetUnstructuredContent(rqObj)
+	rnamespace := uo.GetNamespace()
+	rname := uo.GetName()
+	rnn := types.NamespacedName{Namespace: rnamespace, Name: rname}.String()
+
+	gvr, err := GVRFromUnstructured(&uo, m)
+	if err != nil {
+		return fmt.Errorf("failed to determine resource GVR: %s", err)
+	}
+
+	ns, err := IsResourceNamespaced(gvk, m)
+	if err != nil {
+		return fmt.Errorf("failed to discover scope of resource %q: %v", rnn, err)
+	}
+
+	var rs dynamic.ResourceInterface
+	if ns {
+		rs = c.Resource(gvr).Namespace(rnamespace)
+	} else {
+		rs = c.Resource(gvr)
+	}
+
+	jsonManifest, err := uo.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("failed to marshall resource %q to JSON: %v", rnn, err)
+	}
+
+	// Call the Kubernetes API to create the new resource
+	_, err = rs.Patch(ctx, rname, types.ApplyPatchType, jsonManifest,
+		metav1.PatchOptions{
+			FieldManager: "Terraform",
+			DryRun:       []string{"All"},
+		},
+	)
+
+	return err
+}
 
 // PlanResourceChange function
 func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfprotov5.PlanResourceChangeRequest) (*tfprotov5.PlanResourceChangeResponse, error) {
@@ -138,13 +204,21 @@ func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfproto
 		// type information we can get from the config
 		objectType = ppMan.Type()
 
-		// TODO dry run here to catch any types added on the server side
-
 		resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
 			Severity: tfprotov5.DiagnosticSeverityWarning,
 			Summary:  "This custom resource does not have an associated OpenAPI schema.",
 			Detail:   "We could not find an OpenAPI schema for this custom resource. Updates to this resource will cause a forced replacement.",
 		})
+
+		err := s.dryRun(ctx, ppMan)
+		if err != nil {
+			resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+				Severity: tfprotov5.DiagnosticSeverityError,
+				Summary:  "Dry-run failed for non-structured resource",
+				Detail:   fmt.Sprintf("A dry-run apply was performed for this resource but was unsuccessful: %v", err),
+			})
+			return resp, nil
+		}
 
 		manifest := tftypes.AttributePath{}.WithAttributeName("manifest")
 		object := tftypes.AttributePath{}.WithAttributeName("object")

--- a/provider/plan.go
+++ b/provider/plan.go
@@ -31,7 +31,7 @@ func (s *RawProviderServer) dryRun(ctx context.Context, obj tftypes.Value) error
 	}
 
 	minObj := morph.UnknownToNull(obj)
-	pu, err := payload.FromTFValue(minObj, tftypes.AttributePath{})
+	pu, err := payload.FromTFValue(minObj, tftypes.NewAttributePath())
 	if err != nil {
 		return err
 	}
@@ -64,8 +64,6 @@ func (s *RawProviderServer) dryRun(ctx context.Context, obj tftypes.Value) error
 	if err != nil {
 		return fmt.Errorf("failed to marshall resource %q to JSON: %v", rnn, err)
 	}
-
-	// Call the Kubernetes API to create the new resource
 	_, err = rs.Patch(ctx, rname, types.ApplyPatchType, jsonManifest,
 		metav1.PatchOptions{
 			FieldManager: "Terraform",
@@ -220,11 +218,9 @@ func (s *RawProviderServer) PlanResourceChange(ctx context.Context, req *tfproto
 			return resp, nil
 		}
 
-		manifest := tftypes.AttributePath{}.WithAttributeName("manifest")
-		object := tftypes.AttributePath{}.WithAttributeName("object")
 		resp.RequiresReplace = []*tftypes.AttributePath{
-			&manifest,
-			&object,
+			tftypes.NewAttributePath().WithAttributeName("manifest"),
+			tftypes.NewAttributePath().WithAttributeName("object"),
 		}
 	}
 

--- a/provider/read.go
+++ b/provider/read.go
@@ -138,7 +138,7 @@ func (s *RawProviderServer) ReadResource(ctx context.Context, req *tfprotov5.Rea
 		return resp, fmt.Errorf("failed to determine resource type ID: %s", err)
 	}
 
-	fo := FilterEphemeralFields(ro.Object)
+	fo := RemoveServerSideFields(ro.Object)
 	nobj, err := payload.ToTFValue(fo, objectType, tftypes.NewAttributePath())
 	if err != nil {
 		return resp, err

--- a/provider/resource.go
+++ b/provider/resource.go
@@ -134,9 +134,9 @@ func sliceRemoveNulls(in []interface{}) []interface{} {
 	return s
 }
 
-// FilterEphemeralFields removes certain fields from an API response object
-// which would otherwise cause a false diff
-func FilterEphemeralFields(in map[string]interface{}) map[string]interface{} {
+// RemoveServerSideFields removes certain fields which get added to the
+// resource after creation which would cause a perpetual diff
+func RemoveServerSideFields(in map[string]interface{}) map[string]interface{} {
 	// Remove "status" attribute
 	delete(in, "status")
 

--- a/test/acceptance/nonstructuredcustomresource_test.go
+++ b/test/acceptance/nonstructuredcustomresource_test.go
@@ -1,0 +1,101 @@
+// +build acceptance
+
+package acceptance
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-provider-kubernetes-alpha/provider"
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes-alpha/test/helper/state"
+)
+
+func TestKubernetesManifest_NonStructuredCustomResource(t *testing.T) {
+	kind := randName()
+	plural := strings.ToLower(kind) + "s"
+	group := "k8s.terraform.io"
+	version := "v1"
+	groupVersion := group + "/" + version
+	crd := fmt.Sprintf("%s.%s", plural, group)
+
+	name := strings.ToLower(randName())
+	namespace := randName()
+
+	k8shelper.CreateNamespace(t, namespace)
+
+	tfvars := TFVARS{
+		"name":          name,
+		"namespace":     namespace,
+		"kind":          kind,
+		"plural":        plural,
+		"group":         group,
+		"group_version": groupVersion,
+		"cr_version":    version,
+		"testdata":      "hello world",
+	}
+
+	step1 := tfhelper.RequireNewWorkingDir(t)
+	step1.SetReattachInfo(reattachInfo)
+	defer func() {
+		step1.RequireDestroy(t)
+		step1.Close()
+		k8shelper.AssertResourceDoesNotExist(t, "apiextensions.k8s.io/v1beta1", "customresourcedefinitions", crd)
+	}()
+
+	// create the CRD for the non-structured resource
+	tfconfig := loadTerraformConfig(t, "NonStructuredCustomResourceDefinition/customresourcedefinition.tf", tfvars)
+	step1.RequireSetConfig(t, string(tfconfig))
+	step1.RequireInit(t)
+	step1.RequireApply(t)
+	k8shelper.AssertResourceExists(t, "apiextensions.k8s.io/v1beta1", "customresourcedefinitions", crd)
+
+	// wait for API to finish ingesting the CRD
+	time.Sleep(5 * time.Second) //lintignore:R018
+
+	reattachInfo2, err := provider.ServeTest(context.TODO(), hclog.Default())
+	if err != nil {
+		t.Errorf("Failed to create additional provider instance: %q", err)
+	}
+	step2 := tfhelper.RequireNewWorkingDir(t)
+	step2.SetReattachInfo(reattachInfo2)
+	defer func() {
+		step2.RequireDestroy(t)
+		step2.Close()
+		k8shelper.AssertResourceDoesNotExist(t, groupVersion, plural, name)
+	}()
+
+	// create non-structured resource
+	tfconfig = loadTerraformConfig(t, "NonStructuredCustomResource/custom_resource.tf", tfvars)
+	step2.RequireSetConfig(t, string(tfconfig))
+	step2.RequireInit(t)
+	step2.RequireApply(t)
+
+	tfstate := tfstatehelper.NewHelper(step2.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.name":        name,
+		"kubernetes_manifest.test.object.metadata.namespace":   namespace,
+		"kubernetes_manifest.test.object.data.nested.testdata": "hello world",
+	})
+
+	// update the non-structured resource
+	tfvars["testdata"] = "updated"
+	tfconfig = loadTerraformConfig(t, "NonStructuredCustomResource/custom_resource.tf", tfvars)
+	step2.RequireSetConfig(t, string(tfconfig))
+	step2.RequireInit(t)
+	step2.RequireApply(t)
+
+	// updating a non-structured custom resource should force a replacement
+	// so the generation should be 1
+	k8shelper.AssertResourceGeneration(t, groupVersion, plural, namespace, name, 1)
+
+	tfstate = tfstatehelper.NewHelper(step2.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.name":        name,
+		"kubernetes_manifest.test.object.metadata.namespace":   namespace,
+		"kubernetes_manifest.test.object.data.nested.testdata": "updated",
+	})
+}

--- a/test/acceptance/testdata/NonStructuredCustomResource/custom_resource.tf
+++ b/test/acceptance/testdata/NonStructuredCustomResource/custom_resource.tf
@@ -1,0 +1,20 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = var.group_version
+    kind       = var.kind
+    metadata = {
+      namespace = var.namespace
+      name      = var.name
+    }
+    data = {
+      nested = {
+        testdata = var.testdata
+      }
+    }
+  }
+}

--- a/test/acceptance/testdata/NonStructuredCustomResource/variables.tf
+++ b/test/acceptance/testdata/NonStructuredCustomResource/variables.tf
@@ -1,0 +1,28 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}
+
+variable "group_version" {
+  type = string
+}
+
+variable "kind" {
+  type = string
+}
+
+variable "testdata" {
+  type = "string"
+}

--- a/test/acceptance/testdata/NonStructuredCustomResourceDefinition/customresourcedefinition.tf
+++ b/test/acceptance/testdata/NonStructuredCustomResourceDefinition/customresourcedefinition.tf
@@ -11,6 +11,7 @@ resource "kubernetes_manifest" "test" {
       name = "${var.plural}.${var.group}"
     }
     spec = {
+      preserveUnknownFields = true
       group = var.group
       names = {
         kind   = var.kind

--- a/test/acceptance/testdata/NonStructuredCustomResourceDefinition/customresourcedefinition.tf
+++ b/test/acceptance/testdata/NonStructuredCustomResourceDefinition/customresourcedefinition.tf
@@ -1,0 +1,27 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "apiextensions.k8s.io/v1beta1"
+    kind       = "CustomResourceDefinition"
+    metadata = {
+      name = "${var.plural}.${var.group}"
+    }
+    spec = {
+      group = var.group
+      names = {
+        kind   = var.kind
+        plural = var.plural
+      }
+      scope = "Namespaced"
+      versions = [{
+        name    = var.cr_version
+        served  = true
+        storage = true
+      }]
+    }
+  }
+}

--- a/test/acceptance/testdata/NonStructuredCustomResourceDefinition/variables.tf
+++ b/test/acceptance/testdata/NonStructuredCustomResourceDefinition/variables.tf
@@ -1,0 +1,24 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "cr_version" {
+  type = string
+}
+
+variable "group" {
+  type = string
+}
+
+variable "kind" {
+  type = string
+}
+
+variable "plural" {
+  type = string
+}


### PR DESCRIPTION
This PR brings in support for non-strucured CRDs, which currently error out when used with the provider.

Non-structured custom resources have CRDs which have an empty schema. This means their body outside of the metadata can be any arbitrary structure and we can't infer it from the OpenAPI spec for the cluster. In this case we make a best effort attempt to guess the type information from the config.

### Example

crd:
```hcl
---
apiVersion: apiextensions.k8s.io/v1beta1
kind: CustomResourceDefinition
metadata:
  name: dummies.k8s.terraform.us
spec:
  group: k8s.terraform.us
  version: v1alpha1
  names:
    kind: Dummy
    plural: dummies
    singular: dummy
  scope: Namespaced
```

config:
```hcl
provider "kubernetes-alpha" {
  config_path = "~/.kube/config"
}

resource "kubernetes_manifest" "dummy_test" {
  provider = kubernetes-alpha

  manifest = {
    "apiVersion" = "k8s.terraform.io/v1alpha1"
    "kind" = "Dummy"
    "metadata" = {
      "name" = "test"
      "namespace" = "default"
    }
    "data" = {
      "test" = {
        "hello" = "world",
        "nested" = {
          "test": true
        },
        "list" = [1, 2, 3],
      },
    }
  }
}
```

output:
```
$ terraform plan
Terraform will perform the following actions:

  # kubernetes_manifest.dummy_test will be created
  + resource "kubernetes_manifest" "dummy_test" {
      + manifest = {
          + apiVersion = "k8s.terraform.io/v1alpha1"
          + data       = {
              + test = {
                  + hello  = "world"
                  + list   = [
                      + 1,
                      + 2,
                      + 3,
                    ]
                  + nested = {
                      + test = true
                    }
                }
            }
          + kind       = "Dummy"
          + metadata   = {
              + name      = "test"
              + namespace = "default"
            }
        }
      + object   = {
          + apiVersion = "k8s.terraform.io/v1alpha1"
          + data       = {
              + test = {
                  + hello  = "world"
                  + list   = [
                      + 1,
                      + 2,
                      + 3,
                    ]
                  + nested = {
                      + test = true
                    }
                }
            }
          + kind       = "Dummy"
          + metadata   = {
              + name      = "test"
              + namespace = "default"
            }
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
╷
│ Warning: This custom resource does not have an associated OpenAPI schema.
│
│   on main.tf line 5:
│   (source code not available)
│
│ We could not find an OpenAPI schema for this custom resource. Updates to this resource will cause a forced replacement.

$ terraform apply --auto-approve                                                                                                                            
kubernetes_manifest.dummy_test: Creating...
kubernetes_manifest.dummy_test: Creation complete after 0s
╷
│ Warning: This custom resource does not have an associated OpenAPI schema.
│
│   on main.tf line 5:
│   (source code not available)
│
│ We could not find an OpenAPI schema for this custom resource. Updates to this resource will cause a forced replacement.
│
│ (and one more similar warning elsewhere)
╵

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add support for non-structured custom resources
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
