### PR TITLE
Fixes for empty lists, sets and maps and lists containing dynamicPseudoType

### DIFF
--- a/morph/morph.go
+++ b/morph/morph.go
@@ -311,7 +311,11 @@ func morphObjectToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath
 				ovals[k] = tftypes.NewValue(t.(tftypes.Object).AttributeTypes[k], nil)
 			}
 		}
-		return tftypes.NewValue(t, ovals), nil
+		otypes := make(map[string]tftypes.Type, len(ovals))
+		for k, v := range ovals {
+			otypes[k] = v.Type()
+		}
+		return tftypes.NewValue(tftypes.Object{AttributeTypes: otypes}, ovals), nil
 	case t.Is(tftypes.Map{}):
 		var mvals map[string]tftypes.Value = make(map[string]tftypes.Value, len(vals))
 		for k, v := range vals {

--- a/morph/morph_test.go
+++ b/morph/morph_test.go
@@ -129,6 +129,23 @@ func TestMorphValueToType(t *testing.T) {
 				tftypes.NewValue(tftypes.String, "baz"),
 			}),
 		},
+		// This covers the case were we need to represent lists that contain dynamicPseudoType sub-elements
+		// because the dynamicPseudoType might hold heterogenous types
+		"tuple(single)->tuple": {
+			In: sampleInType{
+				V: tftypes.NewValue(tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.String, tftypes.String, tftypes.String}}, []tftypes.Value{
+					tftypes.NewValue(tftypes.String, "foo"),
+					tftypes.NewValue(tftypes.String, "bar"),
+					tftypes.NewValue(tftypes.String, "baz"),
+				}),
+				T: tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.DynamicPseudoType}},
+			},
+			Out: tftypes.NewValue(tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.DynamicPseudoType, tftypes.DynamicPseudoType, tftypes.DynamicPseudoType}}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "foo"),
+				tftypes.NewValue(tftypes.String, "bar"),
+				tftypes.NewValue(tftypes.String, "baz"),
+			}),
+		},
 		"tuple->list": {
 			In: sampleInType{
 				V: tftypes.NewValue(tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.String, tftypes.String, tftypes.String}}, []tftypes.Value{
@@ -307,6 +324,32 @@ func TestMorphValueToType(t *testing.T) {
 				"one":   tftypes.NewValue(tftypes.String, nil),
 				"two":   tftypes.NewValue(tftypes.String, "bar"),
 				"three": tftypes.NewValue(tftypes.String, "baz"),
+			}),
+		},
+		// morphing to tuple attributes to "template tuples" (containing dynamic) should result in the same number of elements as the input
+		"object(dynamic) -> object": {
+			In: sampleInType{
+				V: tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+					"one": tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.String, tftypes.String}},
+				}}, map[string]tftypes.Value{
+					"one": tftypes.NewValue(tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.String, tftypes.String}},
+						[]tftypes.Value{
+							tftypes.NewValue(tftypes.String, "bar"),
+							tftypes.NewValue(tftypes.String, "baz"),
+						}),
+				}),
+				T: tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+					"one": tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.DynamicPseudoType}},
+				}},
+			},
+			Out: tftypes.NewValue(tftypes.Object{AttributeTypes: map[string]tftypes.Type{
+				"one": tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.DynamicPseudoType, tftypes.DynamicPseudoType}},
+			}}, map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.DynamicPseudoType, tftypes.DynamicPseudoType}},
+					[]tftypes.Value{
+						tftypes.NewValue(tftypes.String, "bar"),
+						tftypes.NewValue(tftypes.String, "baz"),
+					}),
 			}),
 		},
 	}

--- a/payload/to_value_test.go
+++ b/payload/to_value_test.go
@@ -112,6 +112,32 @@ func TestToTFValue(t *testing.T) {
 			}),
 			Err: nil,
 		},
+		"list (empty)": {
+			In:  sampleInType{[]interface{}{}, tftypes.List{ElementType: tftypes.String}},
+			Out: tftypes.NewValue(tftypes.List{ElementType: tftypes.String}, []tftypes.Value{}),
+			Err: nil,
+		},
+		"set": {
+			In: sampleInType{[]interface{}{"test1", "test2"}, tftypes.Set{ElementType: tftypes.String}},
+			Out: tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "test1"),
+				tftypes.NewValue(tftypes.String, "test2"),
+			}),
+			Err: nil,
+		},
+		"set (empty)": {
+			In:  sampleInType{[]interface{}{}, tftypes.Set{ElementType: tftypes.String}},
+			Out: tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{}),
+			Err: nil,
+		},
+		"tuple": {
+			In: sampleInType{[]interface{}{"test1", "test2"}, tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.String, tftypes.String}}},
+			Out: tftypes.NewValue(tftypes.Tuple{ElementTypes: []tftypes.Type{tftypes.String, tftypes.String}}, []tftypes.Value{
+				tftypes.NewValue(tftypes.String, "test1"),
+				tftypes.NewValue(tftypes.String, "test2"),
+			}),
+			Err: nil,
+		},
 		"map": {
 			In: sampleInType{
 				v: map[string]interface{}{

--- a/test/acceptance/customresourcedefinition_test.go
+++ b/test/acceptance/customresourcedefinition_test.go
@@ -61,5 +61,24 @@ func TestKubernetesManifest_CustomResourceDefinition(t *testing.T) {
 				},
 			},
 		},
+		"kubernetes_manifest.test.object.spec.versions.1.name":    version + "beta1",
+		"kubernetes_manifest.test.object.spec.versions.1.served":  true,
+		"kubernetes_manifest.test.object.spec.versions.1.storage": false,
+		"kubernetes_manifest.test.object.spec.versions.1.schema": map[string]interface{}{
+			"openAPIV3Schema": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"data": map[string]interface{}{
+						"type": "string",
+					},
+					"otherData": map[string]interface{}{
+						"type": "string",
+					},
+					"refs": map[string]interface{}{
+						"type": "number",
+					},
+				},
+			},
+		},
 	})
 }

--- a/test/acceptance/testdata/CustomResourceDefinition/customresourcedefinition.tf
+++ b/test/acceptance/testdata/CustomResourceDefinition/customresourcedefinition.tf
@@ -17,24 +17,47 @@ resource "kubernetes_manifest" "test" {
         plural = var.plural
       }
       scope = "Namespaced"
-      versions = [{
-        name    = var.cr_version
-        served  = true
-        storage = true
-        schema = {
-          openAPIV3Schema = {
-            type = "object"
-            properties = {
-              data = {
-                type = "string"
+      versions = [
+        {
+          name    = var.cr_version
+          served  = true
+          storage = true
+          schema = {
+            openAPIV3Schema = {
+              type = "object"
+              properties = {
+                data = {
+                  type = "string"
+                }
+                refs = {
+                  type = "number"
+                }
               }
-              refs = {
-                type = "number"
+            }
+          }
+        },
+        {
+          name    = "${var.cr_version}beta1"
+          served  = true
+          storage = false
+          schema = {
+            openAPIV3Schema = {
+              type = "object"
+              properties = {
+                data = {
+                  type = "string"
+                }
+                otherData = {
+                  type = "string"
+                }
+                refs = {
+                  type = "number"
+                }
               }
             }
           }
         }
-      }]
+      ]
     }
   }
 }


### PR DESCRIPTION
### Description

This change fixes the issues reported in https://github.com/hashicorp/terraform-provider-kubernetes-alpha/issues/212

In particular, it corrects the handling of empty lists, sets and maps. 
It also corrects the morphing of object types so that attribute types are extracted from the morphed attributes' values rather than copied directly from the requested target type. This allows for elements containing morphed tuples (heterogeneous lists) to be correctly carried over in the result object after morphing (main issue reported in #212).

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:

* CRDs with multiple versions now correctly handled again (#212)
* empty list and map attributes are now correctly handled (#212)
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
