### PR TITLE
Add more test coverage of basic resources

### DIFF
--- a/test/acceptance/cronjob_test.go
+++ b/test/acceptance/cronjob_test.go
@@ -1,0 +1,48 @@
+// +build acceptance
+
+package acceptance
+
+import (
+	"testing"
+
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes-alpha/test/helper/state"
+)
+
+func TestKubernetesManifest_CronJob(t *testing.T) {
+	name := randName()
+	namespace := randName()
+
+	tf := tfhelper.RequireNewWorkingDir(t)
+	tf.SetReattachInfo(reattachInfo)
+	defer func() {
+		tf.RequireDestroy(t)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "batch/v1beta1", "cronjobs", namespace, name)
+	}()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteNamespace(t, namespace)
+
+	tfvars := TFVARS{
+		"namespace": namespace,
+		"name":      name,
+	}
+	tfconfig := loadTerraformConfig(t, "CronJob/cronjob.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+	tf.RequireApply(t)
+
+	k8shelper.AssertNamespacedResourceExists(t, "batch/v1beta1", "cronjobs", namespace, name)
+
+	tfstate := tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace": namespace,
+		"kubernetes_manifest.test.object.metadata.name":      name,
+
+		"kubernetes_manifest.test.object.spec.schedule":                                            "0 * * * *",
+		"kubernetes_manifest.test.object.spec.jobTemplate.spec.template.spec.containers.0.name":    "busybox",
+		"kubernetes_manifest.test.object.spec.jobTemplate.spec.template.spec.containers.0.image":   "busybox",
+		"kubernetes_manifest.test.object.spec.jobTemplate.spec.template.spec.containers.0.command": []interface{}{"sleep", "30"},
+		"kubernetes_manifest.test.object.spec.jobTemplate.spec.template.spec.restartPolicy":        "Never",
+	})
+}

--- a/test/acceptance/daemonset_test.go
+++ b/test/acceptance/daemonset_test.go
@@ -1,0 +1,45 @@
+// +build acceptance
+
+package acceptance
+
+import (
+	"testing"
+
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes-alpha/test/helper/state"
+)
+
+func TestKubernetesManifest_DaemonSet(t *testing.T) {
+	name := randName()
+	namespace := randName()
+
+	tf := tfhelper.RequireNewWorkingDir(t)
+	tf.SetReattachInfo(reattachInfo)
+	defer func() {
+		tf.RequireDestroy(t)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "apps/v1", "daemonsets", namespace, name)
+	}()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteNamespace(t, namespace)
+
+	tfvars := TFVARS{
+		"namespace": namespace,
+		"name":      name,
+	}
+	tfconfig := loadTerraformConfig(t, "DaemonSet/daemonset.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+	tf.RequireApply(t)
+
+	k8shelper.AssertNamespacedResourceExists(t, "apps/v1", "daemonsets", namespace, name)
+
+	tfstate := tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace":                                    namespace,
+		"kubernetes_manifest.test.object.metadata.name":                                         name,
+		"kubernetes_manifest.test.object.spec.template.spec.containers.0.name":                  "nginx",
+		"kubernetes_manifest.test.object.spec.template.spec.containers.0.image":                 "nginx:1",
+		"kubernetes_manifest.test.object.spec.template.spec.containers.0.ports.0.containerPort": "80",
+	})
+}

--- a/test/acceptance/hpa_test.go
+++ b/test/acceptance/hpa_test.go
@@ -1,0 +1,78 @@
+// +build acceptance
+
+package acceptance
+
+import (
+	"testing"
+
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes-alpha/test/helper/state"
+)
+
+func TestKubernetesManifest_HPA(t *testing.T) {
+	name := randName()
+	namespace := randName()
+
+	tf := tfhelper.RequireNewWorkingDir(t)
+	tf.SetReattachInfo(reattachInfo)
+	defer func() {
+		tf.RequireDestroy(t)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t,
+			"autoscaling/v2beta2", "horizontalpodautoscalers", namespace, name)
+	}()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteNamespace(t, namespace)
+
+	tfvars := TFVARS{
+		"namespace": namespace,
+		"name":      name,
+	}
+	tfconfig := loadTerraformConfig(t, "HPA/hpa.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+	tf.RequireApply(t)
+
+	k8shelper.AssertNamespacedResourceExists(t,
+		"autoscaling/v2beta2", "horizontalpodautoscalers", namespace, name)
+
+	tfstate := tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace": namespace,
+		"kubernetes_manifest.test.object.metadata.name":      name,
+
+		"kubernetes_manifest.test.object.spec.scaleTargetRef.apiVersion": "apps/v1",
+		"kubernetes_manifest.test.object.spec.scaleTargetRef.kind":       "Deployment",
+		"kubernetes_manifest.test.object.spec.scaleTargetRef.name":       "nginx",
+
+		"kubernetes_manifest.test.object.spec.maxReplicas": "10",
+		"kubernetes_manifest.test.object.spec.minReplicas": "1",
+
+		"kubernetes_manifest.test.object.spec.metrics.0.type":                               "Resource",
+		"kubernetes_manifest.test.object.spec.metrics.0.resource.name":                      "cpu",
+		"kubernetes_manifest.test.object.spec.metrics.0.resource.target.type":               "Utilization",
+		"kubernetes_manifest.test.object.spec.metrics.0.resource.target.averageUtilization": "50",
+	})
+
+	tfconfigModified := loadTerraformConfig(t, "HPA/hpa_modified.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfigModified)
+	tf.RequireApply(t)
+
+	tfstate = tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace": namespace,
+		"kubernetes_manifest.test.object.metadata.name":      name,
+
+		"kubernetes_manifest.test.object.spec.scaleTargetRef.apiVersion": "apps/v1",
+		"kubernetes_manifest.test.object.spec.scaleTargetRef.kind":       "Deployment",
+		"kubernetes_manifest.test.object.spec.scaleTargetRef.name":       "nginx",
+
+		"kubernetes_manifest.test.object.spec.maxReplicas": "20",
+		"kubernetes_manifest.test.object.spec.minReplicas": "1",
+
+		"kubernetes_manifest.test.object.spec.metrics.0.type":                               "Resource",
+		"kubernetes_manifest.test.object.spec.metrics.0.resource.name":                      "cpu",
+		"kubernetes_manifest.test.object.spec.metrics.0.resource.target.type":               "Utilization",
+		"kubernetes_manifest.test.object.spec.metrics.0.resource.target.averageUtilization": "65",
+	})
+}

--- a/test/acceptance/job_test.go
+++ b/test/acceptance/job_test.go
@@ -1,0 +1,46 @@
+// +build acceptance
+
+package acceptance
+
+import (
+	"testing"
+
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes-alpha/test/helper/state"
+)
+
+func TestKubernetesManifest_Job(t *testing.T) {
+	name := randName()
+	namespace := randName()
+
+	tf := tfhelper.RequireNewWorkingDir(t)
+	tf.SetReattachInfo(reattachInfo)
+	defer func() {
+		tf.RequireDestroy(t)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "batch/v1", "jobs", namespace, name)
+	}()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteNamespace(t, namespace)
+
+	tfvars := TFVARS{
+		"namespace": namespace,
+		"name":      name,
+	}
+	tfconfig := loadTerraformConfig(t, "Job/job.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+	tf.RequireApply(t)
+
+	k8shelper.AssertNamespacedResourceExists(t, "batch/v1", "jobs", namespace, name)
+
+	tfstate := tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace":                      namespace,
+		"kubernetes_manifest.test.object.metadata.name":                           name,
+		"kubernetes_manifest.test.object.spec.template.spec.containers.0.name":    "busybox",
+		"kubernetes_manifest.test.object.spec.template.spec.containers.0.image":   "busybox",
+		"kubernetes_manifest.test.object.spec.template.spec.containers.0.command": []interface{}{"sleep", "30"},
+		"kubernetes_manifest.test.object.spec.template.spec.restartPolicy":        "Never",
+	})
+}

--- a/test/acceptance/namespace_test.go
+++ b/test/acceptance/namespace_test.go
@@ -1,0 +1,46 @@
+// +build acceptance
+
+package acceptance
+
+import (
+	"testing"
+
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes-alpha/test/helper/state"
+)
+
+func TestKubernetesManifest_Namespace(t *testing.T) {
+	name := randName()
+
+	tf := tfhelper.RequireNewWorkingDir(t)
+	tf.SetReattachInfo(reattachInfo)
+	defer func() {
+		tf.RequireDestroy(t)
+		tf.Close()
+		k8shelper.AssertResourceDoesNotExist(t, "v1", "namespaces", name)
+	}()
+
+	tfvars := TFVARS{
+		"name": name,
+	}
+	tfconfig := loadTerraformConfig(t, "Namespace/namespace.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+	tf.RequireApply(t)
+
+	k8shelper.AssertResourceExists(t, "v1", "namespaces", name)
+
+	tfstate := tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.name": name,
+	})
+
+	tfconfigModified := loadTerraformConfig(t, "Namespace/namespace_modified.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfigModified)
+	tf.RequireApply(t)
+
+	tfstate = tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.name":        name,
+		"kubernetes_manifest.test.object.metadata.labels.test": "test",
+	})
+}

--- a/test/acceptance/secret_test.go
+++ b/test/acceptance/secret_test.go
@@ -1,0 +1,45 @@
+// +build acceptance
+
+package acceptance
+
+import (
+	"testing"
+
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes-alpha/test/helper/state"
+)
+
+func TestKubernetesManifest_Secret(t *testing.T) {
+	name := randName()
+	namespace := randName()
+
+	tf := tfhelper.RequireNewWorkingDir(t)
+	tf.SetReattachInfo(reattachInfo)
+	defer func() {
+		tf.RequireDestroy(t)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "v1", "secrets", namespace, name)
+	}()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteNamespace(t, namespace)
+
+	tfvars := TFVARS{
+		"namespace": namespace,
+		"name":      name,
+	}
+	tfconfig := loadTerraformConfig(t, "Secret/secret.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+	tf.RequireApply(t)
+
+	k8shelper.AssertNamespacedResourceExists(t, "v1", "secrets", namespace, name)
+
+	tfstate := tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace": namespace,
+		"kubernetes_manifest.test.object.metadata.name":      name,
+
+		"kubernetes_manifest.test.object.data.PGUSER":     "username",
+		"kubernetes_manifest.test.object.data.PGPASSWORD": "password",
+	})
+}

--- a/test/acceptance/statefulset_test.go
+++ b/test/acceptance/statefulset_test.go
@@ -1,0 +1,58 @@
+// +build acceptance
+
+package acceptance
+
+import (
+	"testing"
+
+	tfstatehelper "github.com/hashicorp/terraform-provider-kubernetes-alpha/test/helper/state"
+)
+
+func TestKubernetesManifest_StatefulSet(t *testing.T) {
+	name := randName()
+	namespace := randName()
+
+	tf := tfhelper.RequireNewWorkingDir(t)
+	tf.SetReattachInfo(reattachInfo)
+	defer func() {
+		tf.RequireDestroy(t)
+		tf.Close()
+		k8shelper.AssertNamespacedResourceDoesNotExist(t, "apps/v1", "statefulsets", namespace, name)
+	}()
+
+	k8shelper.CreateNamespace(t, namespace)
+	defer k8shelper.DeleteNamespace(t, namespace)
+
+	tfvars := TFVARS{
+		"namespace": namespace,
+		"name":      name,
+	}
+	tfconfig := loadTerraformConfig(t, "StatefulSet/statefulset.tf", tfvars)
+	tf.RequireSetConfig(t, tfconfig)
+	tf.RequireInit(t)
+	tf.RequireApply(t)
+
+	k8shelper.AssertNamespacedResourceExists(t, "apps/v1", "statefulsets", namespace, name)
+
+	tfstate := tfstatehelper.NewHelper(tf.RequireState(t))
+	tfstate.AssertAttributeValues(t, tfstatehelper.AttributeValues{
+		"kubernetes_manifest.test.object.metadata.namespace": namespace,
+		"kubernetes_manifest.test.object.metadata.name":      name,
+
+		"kubernetes_manifest.test.object.spec.replicas":                 "2",
+		"kubernetes_manifest.test.object.spec.selector.matchLabels.app": "nginx",
+
+		"kubernetes_manifest.test.object.spec.template.spec.containers.0.name":                     "nginx",
+		"kubernetes_manifest.test.object.spec.template.spec.containers.0.image":                    "nginx:1",
+		"kubernetes_manifest.test.object.spec.template.spec.containers.0.ports.0.containerPort":    "80",
+		"kubernetes_manifest.test.object.spec.template.spec.containers.0.ports.0.name":             "web",
+		"kubernetes_manifest.test.object.spec.template.spec.containers.0.volumeMounts.0.name":      "www",
+		"kubernetes_manifest.test.object.spec.template.spec.containers.0.volumeMounts.0.mountPath": "/usr/share/nginx/html",
+
+		"kubernetes_manifest.test.object.spec.volumeClaimTemplates.0.metadata.name":                   "www",
+		"kubernetes_manifest.test.object.spec.volumeClaimTemplates.0.spec.accessModes.0":              "ReadWriteOnce",
+		"kubernetes_manifest.test.object.spec.volumeClaimTemplates.0.spec.resources.requests.storage": "1Gi",
+	})
+
+	tfstate.AssertAttributeExists(t, "kubernetes_manifest.test.object.spec.serviceName")
+}

--- a/test/acceptance/testdata/CronJob/cronjob.tf
+++ b/test/acceptance/testdata/CronJob/cronjob.tf
@@ -1,0 +1,38 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "batch/v1beta1"
+    kind       = "CronJob"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+    }
+    spec = {
+      schedule = "0 * * * *"
+      jobTemplate = {
+        spec = {
+          template = {
+            metadata = {}
+            spec = {
+              restartPolicy = "Never"
+              containers = [
+                {
+                  image = "busybox"
+                  name  = "busybox"
+                  command = [
+                    "sleep", 
+                    "30"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/acceptance/testdata/CronJob/variables.tf
+++ b/test/acceptance/testdata/CronJob/variables.tf
@@ -1,0 +1,16 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}

--- a/test/acceptance/testdata/DaemonSet/daemonset.tf
+++ b/test/acceptance/testdata/DaemonSet/daemonset.tf
@@ -1,0 +1,46 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "apps/v1"
+    kind       = "DaemonSet"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+      labels = {
+        app = "nginx"
+      }
+    }
+    spec = {
+      selector = {
+        matchLabels = {
+          app = "nginx"
+        }
+      }
+      template = {
+        metadata = {
+          labels = {
+            app = "nginx"
+          }
+        }
+        spec = {
+          containers = [
+            {
+              image = "nginx:1"
+              name  = "nginx"
+              ports = [
+                {
+                  containerPort = 80
+                  protocol      = "TCP"
+                },
+              ]
+            },
+          ]
+        }
+      }
+    }
+  }
+}

--- a/test/acceptance/testdata/DaemonSet/variables.tf
+++ b/test/acceptance/testdata/DaemonSet/variables.tf
@@ -1,0 +1,16 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}

--- a/test/acceptance/testdata/HPA/hpa.tf
+++ b/test/acceptance/testdata/HPA/hpa.tf
@@ -1,0 +1,38 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "autoscaling/v2beta2"
+    kind       = "HorizontalPodAutoscaler"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+    }
+    spec = {
+      scaleTargetRef = {
+        apiVersion = "apps/v1"
+        kind       = "Deployment"
+        name       = "nginx"
+      }
+      
+      maxReplicas = 10
+      minReplicas = 1
+
+      metrics = [
+        {
+          type     = "Resource"
+          resource = {
+            name = "cpu"
+            target = {
+              type               = "Utilization"
+              averageUtilization = 50
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/acceptance/testdata/HPA/hpa_modified.tf
+++ b/test/acceptance/testdata/HPA/hpa_modified.tf
@@ -1,0 +1,38 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "autoscaling/v2beta2"
+    kind       = "HorizontalPodAutoscaler"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+    }
+    spec = {
+      scaleTargetRef = {
+        apiVersion = "apps/v1"
+        kind       = "Deployment"
+        name       = "nginx"
+      }
+      
+      maxReplicas = 20
+      minReplicas = 1
+
+      metrics = [
+        {
+          type     = "Resource"
+          resource = {
+            name = "cpu"
+            target = {
+              type               = "Utilization"
+              averageUtilization = 65
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/test/acceptance/testdata/HPA/variables.tf
+++ b/test/acceptance/testdata/HPA/variables.tf
@@ -1,0 +1,16 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}

--- a/test/acceptance/testdata/Job/job.tf
+++ b/test/acceptance/testdata/Job/job.tf
@@ -1,0 +1,33 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "batch/v1"
+    kind       = "Job"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+    }
+    spec = {
+      template = {
+        metadata = {}
+        spec = {
+          restartPolicy = "Never"
+          containers = [
+            {
+              image = "busybox"
+              name  = "busybox"
+              command = [
+                "sleep", 
+                "30"
+              ]
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/test/acceptance/testdata/Job/variables.tf
+++ b/test/acceptance/testdata/Job/variables.tf
@@ -1,0 +1,16 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}

--- a/test/acceptance/testdata/Namespace/namespace.tf
+++ b/test/acceptance/testdata/Namespace/namespace.tf
@@ -1,0 +1,14 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Namespace"
+    metadata = {
+      name      = var.name
+    }
+  }
+}

--- a/test/acceptance/testdata/Namespace/namespace_modified.tf
+++ b/test/acceptance/testdata/Namespace/namespace_modified.tf
@@ -1,0 +1,17 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Namespace"
+    metadata = {
+      name      = var.name
+      labels = {
+        test = "test"
+      }
+    }
+  }
+}

--- a/test/acceptance/testdata/Namespace/variables.tf
+++ b/test/acceptance/testdata/Namespace/variables.tf
@@ -1,0 +1,12 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}

--- a/test/acceptance/testdata/Secret/secret.tf
+++ b/test/acceptance/testdata/Secret/secret.tf
@@ -1,0 +1,19 @@
+provider "kubernetes-alpha" {
+}
+
+resource "kubernetes_manifest" "test" {
+  provider = kubernetes-alpha
+
+  manifest = {
+    apiVersion = "v1"
+    kind       = "Secret"
+    metadata = {
+      name      = var.name
+      namespace = var.namespace
+    }
+    data = {
+      PGUSER     = "username"
+      PGPASSWORD = "password"
+    }
+  }
+}

--- a/test/acceptance/testdata/Secret/variables.tf
+++ b/test/acceptance/testdata/Secret/variables.tf
@@ -1,0 +1,16 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}

--- a/test/acceptance/testdata/StatefulSet/statefulset.tf
+++ b/test/acceptance/testdata/StatefulSet/statefulset.tf
@@ -1,0 +1,98 @@
+provider kubernetes-alpha {
+}
+
+resource kubernetes_manifest test_svc {
+  provider = kubernetes-alpha
+
+  manifest = {
+    "apiVersion" = "v1"
+    "kind" = "Service"
+    "metadata" = {
+      "labels" = {
+        "app" = "nginx"
+      }
+      "name" = var.name
+      "namespace" = var.namespace
+    }
+    "spec" = {
+      "clusterIP" = "None"
+      "ports" = [
+        {
+          "name" = "web"
+          "port" = 80
+          "protocol" = "TCP"
+        },
+      ]
+      "selector" = {
+        "app" = "nginx"
+      }
+    }
+  }
+}
+
+resource kubernetes_manifest test {
+  provider = kubernetes-alpha
+
+  manifest = {
+    "apiVersion" = "apps/v1"
+    "kind" = "StatefulSet"
+    "metadata" = {
+      "name" = var.name
+      "namespace" = var.namespace
+    }
+    "spec" = {
+      "replicas" = 2
+      "selector" = {
+        "matchLabels" = {
+          "app" = "nginx"
+        }
+      }
+      "serviceName" = var.name
+      "template" = {
+        "metadata" = {
+          "labels" = {
+            "app" = "nginx"
+          }
+        }
+        "spec" = {
+          "containers" = [
+            {
+              "image" = "nginx:1"
+              "name" = "nginx"
+              "ports" = [
+                {
+                  "containerPort" = 80
+                  "name" = "web"
+                  "protocol" = "TCP"
+                },
+              ]
+              "volumeMounts" = [
+                {
+                  "mountPath" = "/usr/share/nginx/html"
+                  "name" = "www"
+                },
+              ]
+            },
+          ]
+        }
+      }
+      "volumeClaimTemplates" = [
+        {
+          "metadata" = {
+            "name" = "www"
+          }
+          "spec" = {
+            "accessModes" = [
+              "ReadWriteOnce",
+            ]
+            "resources" = {
+              "requests" = {
+                "storage" = "1Gi"
+              }
+            }
+          }
+        },
+      ]
+    }
+  }
+}

--- a/test/acceptance/testdata/StatefulSet/variables.tf
+++ b/test/acceptance/testdata/StatefulSet/variables.tf
@@ -1,0 +1,16 @@
+# These variable declarations are only used for interactive testing.
+# The test code will template in different variable declarations with a default value when running the test.
+#
+# To set values for interactive runs, create a var-file and set values in it. 
+# If the name of the var-file ends in '.auto.tfvars' (e.g. myvalues.auto.tfvars) 
+# it will be automatically picked up and used by Terraform.
+#
+# DO NOT check in any files named *.auto.tfvars when making changes to tests.
+
+variable "name" {
+  type = string
+}
+
+variable "namespace" {
+  type = string
+}


### PR DESCRIPTION
This PR adds acceptance tests for DaemonSet, StatefulSet, Job, CronJob, Secret, Namespace, and HPA.

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
