### PR TITLE
Fix typo in ApplyResourceChange

### DIFF
--- a/provider/apply.go
+++ b/provider/apply.go
@@ -57,7 +57,7 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 		resp.Diagnostics = append(resp.Diagnostics,
 			&tfprotov5.Diagnostic{
 				Severity: tfprotov5.DiagnosticSeverityError,
-				Summary:  "Failed to retrieve Kubrentes dynamic client during apply",
+				Summary:  "Failed to retrieve Kubernetes dynamic client during apply",
 				Detail:   err.Error(),
 			})
 		return resp, nil
@@ -67,7 +67,7 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 		resp.Diagnostics = append(resp.Diagnostics,
 			&tfprotov5.Diagnostic{
 				Severity: tfprotov5.DiagnosticSeverityError,
-				Summary:  "Failed to retrieve Kubrentes RESTMapper client during apply",
+				Summary:  "Failed to retrieve Kubernetes RESTMapper client during apply",
 				Detail:   err.Error(),
 			})
 		return resp, nil


### PR DESCRIPTION
### Description

Just a small typo we've found when getting a apply error 😄 

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```NONE
...
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
