### PR TITLE
Make `env` and `args` attributes of `exec` block optional

### DIFF
--- a/provider/provider_config.go
+++ b/provider/provider_config.go
@@ -150,6 +150,10 @@ func GetProviderConfigSchema() *tfprotov5.Schema {
 						"env":         tftypes.Map{AttributeType: tftypes.String},
 						"args":        tftypes.List{ElementType: tftypes.String},
 					},
+					OptionalAttributes: map[string]struct{}{
+						"env":  {},
+						"args": {},
+					},
 				},
 				Description:     "",
 				Required:        false,


### PR DESCRIPTION
### Description
Allows `env` and `args` attributes of `exec` block in provider configuration to be optional.
<!--- Please leave a helpful description of the pull request here. --->

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:

* `exec` block in provider configuration no longer requires `env` and `args` to be specified
```
### References
Fixes:
#223 
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
