### PR TITLE
Throw error when Tuple contains mixed Types

### DIFF
--- a/provider/validate.go
+++ b/provider/validate.go
@@ -53,6 +53,7 @@ func (s *RawProviderServer) ValidateResourceTypeConfig(ctx context.Context, req 
 				if tupleElem.Type().Is(tftypes.Object{}) {
 					containsObjects = true
 					tupleElem.As(&objectAsMap)
+
 				}
 
 				// Collect the element types from the Object.
@@ -64,6 +65,11 @@ func (s *RawProviderServer) ValidateResourceTypeConfig(ctx context.Context, req 
 				// Check the list of element types.
 				_, err := tftypes.TypeFromElements(elementTypes)
 				if err != nil {
+					resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  "Tuple element failed validation:" + tupleElem.String(),
+						Detail: err.Error(),
+					})
 					return false, err
 				}
 			}
@@ -71,6 +77,11 @@ func (s *RawProviderServer) ValidateResourceTypeConfig(ctx context.Context, req 
 			if !containsObjects {
 				_, err := tftypes.TypeFromElements(tuple)
 				if err != nil {
+					resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Summary:  "Tuple failed validation:" + val.String(),
+						Detail: err.Error(),
+					})
 					return false, err
 				}
 			}

--- a/provider/validate.go
+++ b/provider/validate.go
@@ -36,7 +36,7 @@ func (s *RawProviderServer) ValidateResourceTypeConfig(ctx context.Context, req 
 	}
 
 	err = tftypes.Walk(config, func(path *tftypes.AttributePath, val tftypes.Value) (bool, error) {
-		if val.Type().Is(tftypes.Tuple{}){
+		if val.Type().Is(tftypes.Tuple{}) {
 			resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
 				Severity: tfprotov5.DiagnosticSeverityError,
 				Summary:  "Values for Lists and Maps must be all one type. Received list with mixed types: " + val.Type().String(),

--- a/provider/validate.go
+++ b/provider/validate.go
@@ -68,7 +68,7 @@ func (s *RawProviderServer) ValidateResourceTypeConfig(ctx context.Context, req 
 				}
 			}
 			// If a Tuple contains no Objects, its elements can be checked.
-			if ! containsObjects {
+			if !containsObjects {
 				_, err := tftypes.TypeFromElements(tuple)
 				if err != nil {
 					return false, err


### PR DESCRIPTION
In Terraform's type system, Lists and Maps must have consistent element types. However, the Kubernetes API spec defines certain fields as type IntOrString, which can lead to using more than one type in a list. Since Terraform has no equivalent type to translate this to, the solution is make each element of the List or Map the same type. Validation will fail if more than one type is used.

Fixes https://github.com/hashicorp/terraform-provider-kubernetes-alpha/issues/231

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix crash when lists contain more than one element Type
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
