### PR TITLE
Add configurable timeout to wait_for

### DIFF
--- a/docs/resources/kubernetes_manifest.md
+++ b/docs/resources/kubernetes_manifest.md
@@ -27,5 +27,6 @@ Once applied, the `object` attribute reflects the state of the resource as retur
 ### Nested Schema for `wait_for`
 
 - **fields** (Map of String)
+- **timeout** (string). Time to wait before timing out. Defaults to `10m`.
 
 

--- a/provider/apply.go
+++ b/provider/apply.go
@@ -188,7 +188,13 @@ func (s *RawProviderServer) ApplyResourceChange(ctx context.Context, req *tfprot
 		if ok {
 			err = s.waitForCompletion(ctx, wf, rs, rname, wt)
 			if err != nil {
-				return resp, err
+				resp.Diagnostics = append(resp.Diagnostics,
+					&tfprotov5.Diagnostic{
+						Severity: tfprotov5.DiagnosticSeverityError,
+						Detail:   err.Error(),
+						Summary:  fmt.Sprintf(`wait_for: timed out waiting on resource %q`, rnn),
+					})
+				return resp, nil
 			}
 		}
 

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -31,6 +31,7 @@ func GetResourceType(name string) (tftypes.Type, error) {
 func GetProviderResourceSchema() map[string]*tfprotov5.Schema {
 	waitForType := tftypes.Object{
 		AttributeTypes: map[string]tftypes.Type{
+			"timeout": tftypes.String,
 			"fields": tftypes.Map{
 				AttributeType: tftypes.String,
 			},

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -36,6 +36,9 @@ func GetProviderResourceSchema() map[string]*tfprotov5.Schema {
 				AttributeType: tftypes.String,
 			},
 		},
+		OptionalAttributes: map[string]struct{}{
+			"timeout": {},
+		},
 	}
 
 	return map[string]*tfprotov5.Schema{

--- a/provider/validate.go
+++ b/provider/validate.go
@@ -101,6 +101,18 @@ func (s *RawProviderServer) ValidateResourceTypeConfig(ctx context.Context, req 
 		}
 	}
 
+	// validate wait_for block
+	if v, ok := configVal["wait_for"]; ok && !v.IsNull() {
+		if err := s.waitForValidate(v); err != nil {
+			resp.Diagnostics = append(resp.Diagnostics, &tfprotov5.Diagnostic{
+				Severity:  tfprotov5.DiagnosticSeverityError,
+				Summary:   `Invalid "wait_for" configuration`,
+				Detail:    err.Error(),
+				Attribute: tftypes.NewAttributePath().WithAttributeName("wait_for"),
+			})
+		}
+	}
+
 	return resp, nil
 }
 


### PR DESCRIPTION
### Description

Adds a configurable timeout to the wait_for block.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-kubernetes/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add configurable timeout to wait_for block
```
### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
