### PR TITLE
Use tftypes ValidateValue to catch panics

### DIFF
--- a/morph/morph.go
+++ b/morph/morph.go
@@ -8,11 +8,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
-
 // ValidateNewValue runs tftypes.ValidateValue before running tftypes.NewValue to ensure the given value will
 // not cause a panic when converted into the specified Type.
 func ValidateNewValue(t tftypes.Type, val interface{}) (tftypes.Value, error) {
-	err:= tftypes.ValidateValue(t, val)
+	err := tftypes.ValidateValue(t, val)
 	if err != nil {
 		return tftypes.Value{}, err
 	}

--- a/morph/morph.go
+++ b/morph/morph.go
@@ -8,9 +8,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
-// ValidateNewValue runs tftypes.ValidateValue before running tftypes.NewValue to ensure the given value will
+// NewValue runs tftypes.ValidateValue before running tftypes.NewValue to ensure the given value will
 // not cause a panic when converted into the specified Type.
-func ValidateNewValue(t tftypes.Type, val interface{}) (tftypes.Value, error) {
+func NewValue(t tftypes.Type, val interface{}) (tftypes.Value, error) {
 	err := tftypes.ValidateValue(t, val)
 	if err != nil {
 		return tftypes.Value{}, err
@@ -63,7 +63,7 @@ func morphBoolToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) 
 	}
 	switch {
 	case t.Is(tftypes.String):
-		return ValidateNewValue(t, strconv.FormatBool(bnat))
+		return NewValue(t, strconv.FormatBool(bnat))
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}
@@ -81,7 +81,7 @@ func morphNumberToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath
 	}
 	switch {
 	case t.Is(tftypes.String):
-		return ValidateNewValue(t, vnat.String())
+		return NewValue(t, vnat.String())
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 
@@ -105,13 +105,13 @@ func morphStringToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath
 			return tftypes.Value{}, p.NewErrorf("[%s] failed to morph string value to tftypes.Number: %v", p.String(), err)
 		}
 		nv := new(big.Float).SetFloat64(fv)
-		return ValidateNewValue(t, nv)
+		return NewValue(t, nv)
 	case t.Is(tftypes.Bool):
 		bv, err := strconv.ParseBool(vnat)
 		if err != nil {
 			return tftypes.Value{}, p.NewErrorf("[%s] failed to morph string value: %v", p.String(), err)
 		}
-		return ValidateNewValue(t, bv)
+		return NewValue(t, bv)
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}
@@ -141,7 +141,7 @@ func morphListToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) 
 			}
 			tvals[i] = nv
 		}
-		return ValidateNewValue(t, tvals)
+		return NewValue(t, tvals)
 	case t.Is(tftypes.Set{}):
 		var svals []tftypes.Value = make([]tftypes.Value, len(lvals))
 		for i, v := range lvals {
@@ -152,7 +152,7 @@ func morphListToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) 
 			}
 			svals[i] = nv
 		}
-		return ValidateNewValue(t, svals)
+		return NewValue(t, svals)
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}
@@ -190,7 +190,7 @@ func morphTupleIntoType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePat
 			}
 			lvals[i] = nv
 		}
-		return ValidateNewValue(tftypes.Tuple{ElementTypes: eltypes}, lvals)
+		return NewValue(tftypes.Tuple{ElementTypes: eltypes}, lvals)
 	case t.Is(tftypes.List{}):
 		var lvals []tftypes.Value = make([]tftypes.Value, len(tvals))
 		for i, v := range tvals {
@@ -201,7 +201,7 @@ func morphTupleIntoType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePat
 			}
 			lvals[i] = nv
 		}
-		return ValidateNewValue(t, lvals)
+		return NewValue(t, lvals)
 	case t.Is(tftypes.Set{}):
 		var svals []tftypes.Value = make([]tftypes.Value, len(tvals))
 		for i, v := range tvals {
@@ -212,7 +212,7 @@ func morphTupleIntoType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePat
 			}
 			svals[i] = nv
 		}
-		return ValidateNewValue(t, svals)
+		return NewValue(t, svals)
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}
@@ -239,7 +239,7 @@ func morphSetToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) (
 			}
 			lvals[i] = nv
 		}
-		return ValidateNewValue(t, lvals)
+		return NewValue(t, lvals)
 	case t.Is(tftypes.Tuple{}):
 		if len(t.(tftypes.Tuple).ElementTypes) != len(svals) {
 			return tftypes.Value{}, p.NewErrorf("[%s] failed to morph list into tuple (length mismatch)", p.String())
@@ -253,7 +253,7 @@ func morphSetToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) (
 			}
 			tvals[i] = nv
 		}
-		return ValidateNewValue(t, tvals)
+		return NewValue(t, tvals)
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}
@@ -280,7 +280,7 @@ func morphMapToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) (
 			}
 			ovals[k] = nv
 		}
-		return ValidateNewValue(t, ovals)
+		return NewValue(t, ovals)
 	case t.Is(tftypes.Map{}):
 		var mvals map[string]tftypes.Value = make(map[string]tftypes.Value, len(mvals))
 		for k, v := range mvals {
@@ -291,7 +291,7 @@ func morphMapToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) (
 			}
 			mvals[k] = nv
 		}
-		return ValidateNewValue(t, mvals)
+		return NewValue(t, mvals)
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}
@@ -319,7 +319,7 @@ func morphObjectToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath
 		// tftypes.NewValue() fails if any of the attributes in the object don't have a corresponding value
 		for k := range t.(tftypes.Object).AttributeTypes {
 			if _, ok := ovals[k]; !ok {
-				ovals[k], err = ValidateNewValue(t.(tftypes.Object).AttributeTypes[k], nil)
+				ovals[k], err = NewValue(t.(tftypes.Object).AttributeTypes[k], nil)
 				if err != nil {
 					return tftypes.Value{}, fmt.Errorf("failed to add nil to object. Check configuration for '{}': %v", err)
 				}
@@ -329,7 +329,7 @@ func morphObjectToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath
 		for k, v := range ovals {
 			otypes[k] = v.Type()
 		}
-		return ValidateNewValue(tftypes.Object{AttributeTypes: otypes}, ovals)
+		return NewValue(tftypes.Object{AttributeTypes: otypes}, ovals)
 	case t.Is(tftypes.Map{}):
 		var mvals map[string]tftypes.Value = make(map[string]tftypes.Value, len(vals))
 		for k, v := range vals {
@@ -340,7 +340,7 @@ func morphObjectToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath
 			}
 			mvals[k] = nv
 		}
-		return ValidateNewValue(t, mvals)
+		return NewValue(t, mvals)
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}

--- a/morph/morph.go
+++ b/morph/morph.go
@@ -1,11 +1,23 @@
 package morph
 
 import (
+	"fmt"
 	"math/big"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
+
+
+// ValidateNewValue runs tftypes.ValidateValue before running tftypes.NewValue to ensure the given value will
+// not cause a panic when converted into the specified Type.
+func ValidateNewValue(t tftypes.Type, val interface{}) (tftypes.Value, error) {
+	err:= tftypes.ValidateValue(t, val)
+	if err != nil {
+		return tftypes.Value{}, err
+	}
+	return tftypes.NewValue(t, val), err
+}
 
 // ValueToType transforms a value along a new type and returns a new value conforming to the given type
 func ValueToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) (tftypes.Value, error) {
@@ -52,7 +64,7 @@ func morphBoolToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) 
 	}
 	switch {
 	case t.Is(tftypes.String):
-		return tftypes.NewValue(t, strconv.FormatBool(bnat)), nil
+		return ValidateNewValue(t, strconv.FormatBool(bnat))
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}
@@ -70,7 +82,7 @@ func morphNumberToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath
 	}
 	switch {
 	case t.Is(tftypes.String):
-		return tftypes.NewValue(t, vnat.String()), nil
+		return ValidateNewValue(t, vnat.String())
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 
@@ -94,13 +106,13 @@ func morphStringToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath
 			return tftypes.Value{}, p.NewErrorf("[%s] failed to morph string value to tftypes.Number: %v", p.String(), err)
 		}
 		nv := new(big.Float).SetFloat64(fv)
-		return tftypes.NewValue(t, nv), nil
+		return ValidateNewValue(t, nv)
 	case t.Is(tftypes.Bool):
 		bv, err := strconv.ParseBool(vnat)
 		if err != nil {
 			return tftypes.Value{}, p.NewErrorf("[%s] failed to morph string value: %v", p.String(), err)
 		}
-		return tftypes.NewValue(t, bv), nil
+		return ValidateNewValue(t, bv)
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}
@@ -130,7 +142,7 @@ func morphListToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) 
 			}
 			tvals[i] = nv
 		}
-		return tftypes.NewValue(t, tvals), nil
+		return ValidateNewValue(t, tvals)
 	case t.Is(tftypes.Set{}):
 		var svals []tftypes.Value = make([]tftypes.Value, len(lvals))
 		for i, v := range lvals {
@@ -141,7 +153,7 @@ func morphListToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) 
 			}
 			svals[i] = nv
 		}
-		return tftypes.NewValue(t, svals), nil
+		return ValidateNewValue(t, svals)
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}
@@ -179,7 +191,7 @@ func morphTupleIntoType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePat
 			}
 			lvals[i] = nv
 		}
-		return tftypes.NewValue(tftypes.Tuple{ElementTypes: eltypes}, lvals), nil
+		return ValidateNewValue(tftypes.Tuple{ElementTypes: eltypes}, lvals)
 	case t.Is(tftypes.List{}):
 		var lvals []tftypes.Value = make([]tftypes.Value, len(tvals))
 		for i, v := range tvals {
@@ -190,7 +202,7 @@ func morphTupleIntoType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePat
 			}
 			lvals[i] = nv
 		}
-		return tftypes.NewValue(t, lvals), nil
+		return ValidateNewValue(t, lvals)
 	case t.Is(tftypes.Set{}):
 		var svals []tftypes.Value = make([]tftypes.Value, len(tvals))
 		for i, v := range tvals {
@@ -201,7 +213,7 @@ func morphTupleIntoType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePat
 			}
 			svals[i] = nv
 		}
-		return tftypes.NewValue(t, svals), nil
+		return ValidateNewValue(t, svals)
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}
@@ -228,7 +240,7 @@ func morphSetToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) (
 			}
 			lvals[i] = nv
 		}
-		return tftypes.NewValue(t, lvals), nil
+		return ValidateNewValue(t, lvals)
 	case t.Is(tftypes.Tuple{}):
 		if len(t.(tftypes.Tuple).ElementTypes) != len(svals) {
 			return tftypes.Value{}, p.NewErrorf("[%s] failed to morph list into tuple (length mismatch)", p.String())
@@ -242,7 +254,7 @@ func morphSetToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) (
 			}
 			tvals[i] = nv
 		}
-		return tftypes.NewValue(t, tvals), nil
+		return ValidateNewValue(t, tvals)
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}
@@ -269,7 +281,7 @@ func morphMapToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) (
 			}
 			ovals[k] = nv
 		}
-		return tftypes.NewValue(t, ovals), nil
+		return ValidateNewValue(t, ovals)
 	case t.Is(tftypes.Map{}):
 		var mvals map[string]tftypes.Value = make(map[string]tftypes.Value, len(mvals))
 		for k, v := range mvals {
@@ -280,7 +292,7 @@ func morphMapToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) (
 			}
 			mvals[k] = nv
 		}
-		return tftypes.NewValue(t, mvals), nil
+		return ValidateNewValue(t, mvals)
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}
@@ -308,14 +320,17 @@ func morphObjectToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath
 		// tftypes.NewValue() fails if any of the attributes in the object don't have a corresponding value
 		for k := range t.(tftypes.Object).AttributeTypes {
 			if _, ok := ovals[k]; !ok {
-				ovals[k] = tftypes.NewValue(t.(tftypes.Object).AttributeTypes[k], nil)
+				ovals[k], err = ValidateNewValue(t.(tftypes.Object).AttributeTypes[k], nil)
+				if err != nil {
+					return tftypes.Value{}, fmt.Errorf("failed to add nil to object. Check configuration for '{}': %v", err)
+				}
 			}
 		}
 		otypes := make(map[string]tftypes.Type, len(ovals))
 		for k, v := range ovals {
 			otypes[k] = v.Type()
 		}
-		return tftypes.NewValue(tftypes.Object{AttributeTypes: otypes}, ovals), nil
+		return ValidateNewValue(tftypes.Object{AttributeTypes: otypes}, ovals)
 	case t.Is(tftypes.Map{}):
 		var mvals map[string]tftypes.Value = make(map[string]tftypes.Value, len(vals))
 		for k, v := range vals {
@@ -326,7 +341,7 @@ func morphObjectToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath
 			}
 			mvals[k] = nv
 		}
-		return tftypes.NewValue(t, mvals), nil
+		return ValidateNewValue(t, mvals)
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}

--- a/morph/morph.go
+++ b/morph/morph.go
@@ -8,9 +8,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
-// NewValue runs tftypes.ValidateValue before running tftypes.NewValue to ensure the given value will
+// newValue runs tftypes.ValidateValue before running tftypes.NewValue to ensure the given value will
 // not cause a panic when converted into the specified Type.
-func NewValue(t tftypes.Type, val interface{}) (tftypes.Value, error) {
+func newValue(t tftypes.Type, val interface{}) (tftypes.Value, error) {
 	err := tftypes.ValidateValue(t, val)
 	if err != nil {
 		return tftypes.Value{}, err
@@ -63,7 +63,7 @@ func morphBoolToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) 
 	}
 	switch {
 	case t.Is(tftypes.String):
-		return NewValue(t, strconv.FormatBool(bnat))
+		return newValue(t, strconv.FormatBool(bnat))
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}
@@ -81,7 +81,7 @@ func morphNumberToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath
 	}
 	switch {
 	case t.Is(tftypes.String):
-		return NewValue(t, vnat.String())
+		return newValue(t, vnat.String())
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 
@@ -105,13 +105,13 @@ func morphStringToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath
 			return tftypes.Value{}, p.NewErrorf("[%s] failed to morph string value to tftypes.Number: %v", p.String(), err)
 		}
 		nv := new(big.Float).SetFloat64(fv)
-		return NewValue(t, nv)
+		return newValue(t, nv)
 	case t.Is(tftypes.Bool):
 		bv, err := strconv.ParseBool(vnat)
 		if err != nil {
 			return tftypes.Value{}, p.NewErrorf("[%s] failed to morph string value: %v", p.String(), err)
 		}
-		return NewValue(t, bv)
+		return newValue(t, bv)
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}
@@ -141,7 +141,7 @@ func morphListToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) 
 			}
 			tvals[i] = nv
 		}
-		return NewValue(t, tvals)
+		return newValue(t, tvals)
 	case t.Is(tftypes.Set{}):
 		var svals []tftypes.Value = make([]tftypes.Value, len(lvals))
 		for i, v := range lvals {
@@ -152,7 +152,7 @@ func morphListToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) 
 			}
 			svals[i] = nv
 		}
-		return NewValue(t, svals)
+		return newValue(t, svals)
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}
@@ -190,7 +190,7 @@ func morphTupleIntoType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePat
 			}
 			lvals[i] = nv
 		}
-		return NewValue(tftypes.Tuple{ElementTypes: eltypes}, lvals)
+		return newValue(tftypes.Tuple{ElementTypes: eltypes}, lvals)
 	case t.Is(tftypes.List{}):
 		var lvals []tftypes.Value = make([]tftypes.Value, len(tvals))
 		for i, v := range tvals {
@@ -201,7 +201,7 @@ func morphTupleIntoType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePat
 			}
 			lvals[i] = nv
 		}
-		return NewValue(t, lvals)
+		return newValue(t, lvals)
 	case t.Is(tftypes.Set{}):
 		var svals []tftypes.Value = make([]tftypes.Value, len(tvals))
 		for i, v := range tvals {
@@ -212,7 +212,7 @@ func morphTupleIntoType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePat
 			}
 			svals[i] = nv
 		}
-		return NewValue(t, svals)
+		return newValue(t, svals)
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}
@@ -239,7 +239,7 @@ func morphSetToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) (
 			}
 			lvals[i] = nv
 		}
-		return NewValue(t, lvals)
+		return newValue(t, lvals)
 	case t.Is(tftypes.Tuple{}):
 		if len(t.(tftypes.Tuple).ElementTypes) != len(svals) {
 			return tftypes.Value{}, p.NewErrorf("[%s] failed to morph list into tuple (length mismatch)", p.String())
@@ -253,7 +253,7 @@ func morphSetToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) (
 			}
 			tvals[i] = nv
 		}
-		return NewValue(t, tvals)
+		return newValue(t, tvals)
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}
@@ -280,7 +280,7 @@ func morphMapToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) (
 			}
 			ovals[k] = nv
 		}
-		return NewValue(t, ovals)
+		return newValue(t, ovals)
 	case t.Is(tftypes.Map{}):
 		var mvals map[string]tftypes.Value = make(map[string]tftypes.Value, len(mvals))
 		for k, v := range mvals {
@@ -291,7 +291,7 @@ func morphMapToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath) (
 			}
 			mvals[k] = nv
 		}
-		return NewValue(t, mvals)
+		return newValue(t, mvals)
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}
@@ -316,10 +316,10 @@ func morphObjectToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath
 			ovals[k] = nv
 		}
 		// for attributes not specified by user add a nil value of their respective type
-		// tftypes.NewValue() fails if any of the attributes in the object don't have a corresponding value
+		// tftypes.newValue() fails if any of the attributes in the object don't have a corresponding value
 		for k := range t.(tftypes.Object).AttributeTypes {
 			if _, ok := ovals[k]; !ok {
-				ovals[k], err = NewValue(t.(tftypes.Object).AttributeTypes[k], nil)
+				ovals[k], err = newValue(t.(tftypes.Object).AttributeTypes[k], nil)
 				if err != nil {
 					return tftypes.Value{}, fmt.Errorf("failed to add nil to object. Check configuration for '{}': %v", err)
 				}
@@ -329,7 +329,7 @@ func morphObjectToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath
 		for k, v := range ovals {
 			otypes[k] = v.Type()
 		}
-		return NewValue(tftypes.Object{AttributeTypes: otypes}, ovals)
+		return newValue(tftypes.Object{AttributeTypes: otypes}, ovals)
 	case t.Is(tftypes.Map{}):
 		var mvals map[string]tftypes.Value = make(map[string]tftypes.Value, len(vals))
 		for k, v := range vals {
@@ -340,7 +340,7 @@ func morphObjectToType(v tftypes.Value, t tftypes.Type, p *tftypes.AttributePath
 			}
 			mvals[k] = nv
 		}
-		return NewValue(t, mvals)
+		return newValue(t, mvals)
 	case t.Is(tftypes.DynamicPseudoType):
 		return v, nil
 	}


### PR DESCRIPTION
### Description

After exploring validation options in https://github.com/hashicorp/terraform-provider-kubernetes-alpha/pull/233, I found I could best support all valid use cases by using [ValidateValue](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go@v0.3.0/tftypes#ValidateValue) prior to running [NewValue](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go@v0.3.0/tftypes#NewValue).

From the docs:
```
If the passed value is not a valid value for the passed type, NewValue will panic. 
Any value and type combination that does not return an error from ValidateValue 
is guaranteed to not panic. When calling NewValue with user input with a type not
 known at compile time, it is recommended to call ValidateValue before calling
 NewValue, to allow graceful handling of the error.
```

This will fix the panic encountered in https://github.com/hashicorp/terraform-provider-kubernetes-alpha/issues/231 and mitigate other panic scenarios.

### Release Note

```release-note
Throw error instead of panic when lists contain more than one element Type
```
### References

https://github.com/hashicorp/terraform-provider-kubernetes-alpha/pull/233
https://github.com/hashicorp/terraform-provider-kubernetes-alpha/issues/231

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
